### PR TITLE
feat(heating): add CommandID 43 heater runtime history to house detail

### DIFF
--- a/backend/houses/tests/test_house_details_heater_history.py
+++ b/backend/houses/tests/test_house_details_heater_history.py
@@ -1,0 +1,78 @@
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from farms.models import Farm
+from houses.models import House
+from rotem_scraper.models import HouseHeaterRuntimeCache
+
+
+class HouseDetailsHeaterHistoryTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="detail_tester",
+            email="detail@test.com",
+            password="testpass123",
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.farm = Farm.objects.create(
+            name="Detail Farm",
+            location="Loc",
+            contact_person="Owner",
+            contact_phone="123456",
+            contact_email="owner@example.com",
+            integration_type="rotem",
+            integration_status="active",
+            has_system_integration=True,
+            is_active=True,
+            rotem_farm_id="detail-farm",
+            rotem_username="user",
+            rotem_password="pass",
+        )
+        self.house = House.objects.create(
+            farm=self.farm,
+            house_number=2,
+            chicken_in_date=date.today() - timedelta(days=10),
+            is_active=True,
+            is_integrated=True,
+        )
+
+    @patch("houses.views.refresh_house_heater_history.delay")
+    def test_house_details_returns_cached_heater_history(self, mock_delay):
+        HouseHeaterRuntimeCache.objects.create(
+            house=self.house,
+            growth_day=10,
+            record_date=date.today(),
+            total_runtime_minutes=180,
+            per_device_json={"device_1": {"minutes": 120}, "device_2": {"minutes": 60}},
+            raw_record_json={"k": "v"},
+        )
+        HouseHeaterRuntimeCache.objects.filter(house=self.house, growth_day=10).update(
+            last_synced_at=timezone.now()
+        )
+
+        response = self.client.get(reverse("house-details", kwargs={"house_id": self.house.id}))
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertIn("heater_history", payload)
+        self.assertEqual(payload["heater_history"]["summary"]["total_minutes"], 180)
+        self.assertEqual(payload["heater_history"]["daily"][0]["growth_day"], 10)
+        self.assertIn(payload["heater_history"]["freshness"]["sync_status"], ["fresh", "refreshing"])
+        mock_delay.assert_not_called()
+
+    @patch("houses.views.refresh_house_heater_history.delay")
+    def test_house_details_triggers_refresh_when_cache_missing(self, mock_delay):
+        response = self.client.get(reverse("house-details", kwargs={"house_id": self.house.id}))
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["heater_history"]["daily"], [])
+        self.assertEqual(payload["heater_history"]["freshness"]["sync_status"], "refreshing")
+        mock_delay.assert_called_once_with(self.house.id)

--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -36,6 +36,8 @@ from tasks.serializers import TaskSerializer
 from collections import defaultdict
 from .services.water_forecast_service import WaterForecastService
 from .services.monitoring_contract import MonitoringUnits
+from rotem_scraper.models import HouseHeaterRuntimeCache
+from rotem_scraper.tasks import refresh_house_heater_history
 
 
 class HouseListCreateView(generics.ListCreateAPIView):
@@ -584,12 +586,101 @@ def house_details(request, house_id):
         else:
             upcoming_tasks.append(task)
     
+    heater_cache_rows = list(
+        HouseHeaterRuntimeCache.objects.filter(house=house).order_by("growth_day")
+    )
+    now = timezone.now()
+    cache_last_synced_at = max(
+        (row.last_synced_at for row in heater_cache_rows),
+        default=None,
+    )
+    cache_stale_after_minutes = 30
+    is_stale = True
+    if cache_last_synced_at:
+        is_stale = (now - cache_last_synced_at).total_seconds() > (cache_stale_after_minutes * 60)
+
+    sync_status = "fresh"
+    if not heater_cache_rows:
+        sync_status = "missing"
+    elif is_stale:
+        sync_status = "stale"
+
+    # Fire-and-forget refresh when cache is missing/stale.
+    if sync_status in {"missing", "stale"}:
+        try:
+            refresh_house_heater_history.delay(house.id)
+            sync_status = "refreshing"
+        except Exception:
+            # Keep response non-blocking even if broker is unavailable.
+            pass
+
+    summary_row = next((row for row in heater_cache_rows if row.is_summary_row), None)
+    daily_rows = [row for row in heater_cache_rows if not row.is_summary_row]
+
+    def _format_per_device(per_device_json):
+        if not isinstance(per_device_json, dict):
+            return {}
+        out = {}
+        for key, value in per_device_json.items():
+            if isinstance(value, dict):
+                minutes = int(value.get("minutes") or 0)
+                out[key] = {
+                    "minutes": minutes,
+                    "hours": round(minutes / 60.0, 2),
+                    "raw_value": value.get("raw_value"),
+                }
+            else:
+                minutes = int(value or 0)
+                out[key] = {
+                    "minutes": minutes,
+                    "hours": round(minutes / 60.0, 2),
+                    "raw_value": None,
+                }
+        return out
+
+    daily_payload = []
+    for row in daily_rows:
+        daily_payload.append({
+            "growth_day": row.growth_day,
+            "date": row.record_date.isoformat() if row.record_date else None,
+            "total_minutes": row.total_runtime_minutes,
+            "total_hours": round(row.total_runtime_minutes / 60.0, 2),
+            "total_computation_method": row.total_computation_method,
+            "per_device": _format_per_device(row.per_device_json),
+            "last_synced_at": row.last_synced_at.isoformat() if row.last_synced_at else None,
+        })
+
+    summary_minutes = sum(item["total_minutes"] for item in daily_payload)
+    device_keys = set()
+    for item in daily_payload:
+        device_keys.update(item["per_device"].keys())
+
+    heater_history = {
+        "summary": {
+            "total_minutes": summary_minutes,
+            "total_hours": round(summary_minutes / 60.0, 2),
+            "days_count": len(daily_payload),
+            "device_count": len(device_keys),
+            "summary_row_minutes": summary_row.total_runtime_minutes if summary_row else None,
+            "summary_row_hours": round(summary_row.total_runtime_minutes / 60.0, 2) if summary_row else None,
+        },
+        "daily": daily_payload,
+        "latest": daily_payload[-1] if daily_payload else None,
+        "freshness": {
+            "last_synced_at": cache_last_synced_at.isoformat() if cache_last_synced_at else None,
+            "stale": is_stale if heater_cache_rows else True,
+            "sync_status": sync_status,
+            "stale_after_minutes": cache_stale_after_minutes,
+        },
+    }
+
     # Build comprehensive response
     details = {
         'house': HouseSerializer(house).data,
         'monitoring': HouseMonitoringSnapshotSerializer(snapshot).data if snapshot else None,
         'alarms': HouseAlarmSerializer(active_alarms, many=True).data,
         'stats': house.get_stats(days=7) if snapshot else None,
+        'heater_history': heater_history,
         'tasks': {
             'all': TaskSerializer(tasks, many=True).data,
             'today': TaskSerializer(today_tasks, many=True).data,

--- a/backend/rotem_scraper/migrations/0007_househeaterruntimecache.py
+++ b/backend/rotem_scraper/migrations/0007_househeaterruntimecache.py
@@ -1,0 +1,83 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("houses", "0009_water_alert_lifecycle_and_forecast"),
+        ("rotem_scraper", "0006_expand_prediction_types"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="HouseHeaterRuntimeCache",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("growth_day", models.IntegerField(help_text="House growth day from Rotem history record")),
+                (
+                    "record_date",
+                    models.DateField(
+                        blank=True,
+                        help_text="Derived from house batch/chicken start date where available",
+                        null=True,
+                    ),
+                ),
+                (
+                    "is_summary_row",
+                    models.BooleanField(
+                        default=False,
+                        help_text="True when record represents summary row (growth_day = -1)",
+                    ),
+                ),
+                ("total_runtime_minutes", models.IntegerField(default=0)),
+                (
+                    "total_computation_method",
+                    models.CharField(
+                        default="provided_total",
+                        help_text="provided_total or sum_devices",
+                        max_length=32,
+                    ),
+                ),
+                ("per_device_json", models.JSONField(default=dict, help_text="Per heater device runtime map")),
+                (
+                    "source_timestamp",
+                    models.DateTimeField(
+                        blank=True,
+                        help_text="Source timestamp from Rotem payload if present",
+                        null=True,
+                    ),
+                ),
+                ("last_synced_at", models.DateTimeField(auto_now=True)),
+                ("raw_record_json", models.JSONField(default=dict, help_text="Raw Rotem row for traceability")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "house",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="heater_runtime_cache",
+                        to="houses.house",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "House Heater Runtime Cache",
+                "verbose_name_plural": "House Heater Runtime Cache",
+                "ordering": ["growth_day"],
+                "unique_together": {("house", "growth_day")},
+            },
+        ),
+        migrations.AddIndex(
+            model_name="househeaterruntimecache",
+            index=models.Index(fields=["house", "growth_day"], name="rotem_scrap_house_i_41ba61_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="househeaterruntimecache",
+            index=models.Index(fields=["house", "record_date"], name="rotem_scrap_house_i_947dc3_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="househeaterruntimecache",
+            index=models.Index(fields=["last_synced_at"], name="rotem_scrap_last_sy_ccf8d9_idx"),
+        ),
+    ]

--- a/backend/rotem_scraper/models.py
+++ b/backend/rotem_scraper/models.py
@@ -252,3 +252,53 @@ class RotemDailySummary(models.Model):
     
     def __str__(self):
         return f"{self.controller.controller_name} - {self.date} (Data Points: {self.total_data_points})"
+
+
+class HouseHeaterRuntimeCache(models.Model):
+    """Cached per-day heater runtime history fetched from Rotem CommandID 43."""
+
+    house = models.ForeignKey(
+        "houses.House",
+        on_delete=models.CASCADE,
+        related_name="heater_runtime_cache",
+    )
+    growth_day = models.IntegerField(help_text="House growth day from Rotem history record")
+    record_date = models.DateField(
+        null=True,
+        blank=True,
+        help_text="Derived from house batch/chicken start date where available",
+    )
+    is_summary_row = models.BooleanField(
+        default=False,
+        help_text="True when record represents summary row (growth_day = -1)",
+    )
+    total_runtime_minutes = models.IntegerField(default=0)
+    total_computation_method = models.CharField(
+        max_length=32,
+        default="provided_total",
+        help_text="provided_total or sum_devices",
+    )
+    per_device_json = models.JSONField(default=dict, help_text="Per heater device runtime map")
+    source_timestamp = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text="Source timestamp from Rotem payload if present",
+    )
+    last_synced_at = models.DateTimeField(auto_now=True)
+    raw_record_json = models.JSONField(default=dict, help_text="Raw Rotem row for traceability")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = ["house", "growth_day"]
+        indexes = [
+            models.Index(fields=["house", "growth_day"]),
+            models.Index(fields=["house", "record_date"]),
+            models.Index(fields=["last_synced_at"]),
+        ]
+        ordering = ["growth_day"]
+        verbose_name = "House Heater Runtime Cache"
+        verbose_name_plural = "House Heater Runtime Cache"
+
+    def __str__(self):
+        return f"House {self.house_id} day {self.growth_day} ({self.total_runtime_minutes} min)"

--- a/backend/rotem_scraper/scraper.py
+++ b/backend/rotem_scraper/scraper.py
@@ -12,6 +12,7 @@ from typing import Dict, Any, Optional
 import argparse
 from urllib.parse import urljoin
 import shlex
+import re
 
 
 class RotemScraper:
@@ -631,6 +632,123 @@ class RotemScraper:
         
         print(f"❌ No water history data found from Rotem API")
         return None
+
+    def _parse_duration_to_minutes(self, value: Any) -> Optional[int]:
+        """Parse duration-like values to integer minutes."""
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return int(round(float(value)))
+
+        raw = str(value).strip()
+        if not raw or raw in {"- - -", "---", "N/A", "null"}:
+            return None
+
+        # Handle 12,5 style decimal values.
+        raw_norm = raw.replace(",", ".")
+        if re.fullmatch(r"-?\d+(\.\d+)?", raw_norm):
+            return int(round(float(raw_norm)))
+
+        parts = raw.split(":")
+        if len(parts) == 2 and all(p.isdigit() for p in parts):
+            hours, minutes = int(parts[0]), int(parts[1])
+            return max((hours * 60) + minutes, 0)
+        if len(parts) == 3 and all(p.isdigit() for p in parts):
+            hours, minutes, seconds = int(parts[0]), int(parts[1]), int(parts[2])
+            return max((hours * 60) + minutes + int(round(seconds / 60.0)), 0)
+        return None
+
+    def parse_heater_history_records(self, command_data: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Normalize CommandID 43 heater runtime data from responseObj.dsData.Data.
+        """
+        normalized = {
+            "records": [],
+            "summary_row": None,
+            "source_timestamp": None,
+        }
+        if not isinstance(command_data, dict):
+            return normalized
+
+        response_obj = command_data.get("reponseObj") or command_data.get("responseObj") or {}
+        ds_data = response_obj.get("dsData") if isinstance(response_obj, dict) else {}
+        rows = ds_data.get("Data") if isinstance(ds_data, dict) else None
+        if not isinstance(rows, list):
+            return normalized
+
+        source_timestamp = command_data.get("source_timestamp") or command_data.get("timestamp")
+        normalized["source_timestamp"] = source_timestamp
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            growth_day_raw = (
+                row.get("HistoryRecord_Heaters_GrowthDay")
+                or row.get("HistoryRecord_GrowthDay")
+                or row.get("GrowthDay")
+            )
+            try:
+                growth_day = int(growth_day_raw)
+            except (TypeError, ValueError):
+                continue
+
+            per_device = {}
+            for key, val in row.items():
+                if "HistoryRecord_Heaters_HeaterDevice_" not in str(key):
+                    continue
+                device_suffix = str(key).split("HistoryRecord_Heaters_HeaterDevice_")[-1]
+                device_key = f"device_{device_suffix}" if device_suffix else "device_unknown"
+                minutes = self._parse_duration_to_minutes(val) or 0
+                per_device[device_key] = {
+                    "minutes": minutes,
+                    "hours": round(minutes / 60.0, 2),
+                    "raw_value": val,
+                }
+
+            total_minutes = None
+            total_keys = [
+                "HistoryRecord_Heaters_Total",
+                "HistoryRecord_Heaters_TotalRuntime",
+                "HistoryRecord_Heaters_Runtime",
+                "HistoryRecord_Heaters_TotalMinutes",
+            ]
+            for total_key in total_keys:
+                if total_key in row:
+                    total_minutes = self._parse_duration_to_minutes(row.get(total_key))
+                    if total_minutes is not None:
+                        break
+
+            computation_method = "provided_total"
+            if total_minutes is None:
+                total_minutes = sum(item["minutes"] for item in per_device.values())
+                computation_method = "sum_devices"
+
+            record = {
+                "growth_day": growth_day,
+                "is_summary_row": growth_day == -1,
+                "total_runtime_minutes": int(total_minutes or 0),
+                "total_runtime_hours": round((total_minutes or 0) / 60.0, 2),
+                "total_computation_method": computation_method,
+                "per_device": per_device,
+                "raw_record": row,
+            }
+            if record["is_summary_row"]:
+                normalized["summary_row"] = record
+            else:
+                normalized["records"].append(record)
+
+        normalized["records"].sort(key=lambda item: item["growth_day"])
+        return normalized
+
+    def get_heater_history(self, house_number: int) -> Optional[Dict[str, Any]]:
+        """Fetch and normalize historical heater runtime (CommandID 43)."""
+        print(f"🔥 Fetching Heater History for House {house_number}...")
+        command_data = self.get_command_data(house_number, command_id="43")
+        if not command_data:
+            return None
+        normalized = self.parse_heater_history_records(command_data)
+        normalized["raw_response"] = command_data
+        return normalized
 
 
 def main():

--- a/backend/rotem_scraper/tasks.py
+++ b/backend/rotem_scraper/tasks.py
@@ -1,10 +1,23 @@
 from celery import shared_task
 from django.utils import timezone
+from datetime import timedelta
 from .services.scraper_service import DjangoRotemScraperService
 from .services.ml_service import MLAnalysisService
+from .models import HouseHeaterRuntimeCache
+from houses.models import House
+from .scraper import RotemScraper
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _derive_record_date(house: House, growth_day: int):
+    if growth_day < 0:
+        return None
+    base_date = house.batch_start_date or house.chicken_in_date
+    if not base_date:
+        return None
+    return base_date + timedelta(days=growth_day)
 
 
 @shared_task(bind=True, max_retries=3)
@@ -179,3 +192,74 @@ def collect_monitoring_data(self, farm_id=None):
     except Exception as exc:
         logger.error(f"Monitoring collection task failed: {str(exc)}")
         raise self.retry(exc=exc, countdown=300)  # Retry after 5 minutes
+
+
+@shared_task(bind=True, max_retries=2)
+def refresh_house_heater_history(self, house_id: int):
+    """Refresh cached house heater runtime history from Rotem CommandID 43."""
+    try:
+        house = House.objects.select_related("farm").get(id=house_id)
+        farm = house.farm
+        if not farm or not farm.rotem_username or not farm.rotem_password:
+            return {
+                "status": "skipped",
+                "reason": "missing_rotem_credentials",
+                "house_id": house_id,
+            }
+
+        scraper = RotemScraper(farm.rotem_username, farm.rotem_password)
+        if not scraper.login():
+            return {
+                "status": "error",
+                "reason": "login_failed",
+                "house_id": house_id,
+                "error": scraper.last_error_message,
+            }
+
+        parsed = scraper.get_heater_history(house_number=house.house_number)
+        if not parsed:
+            return {
+                "status": "error",
+                "reason": "empty_response",
+                "house_id": house_id,
+            }
+
+        source_timestamp = parsed.get("source_timestamp")
+        upserted = 0
+        all_records = list(parsed.get("records", []))
+        summary_row = parsed.get("summary_row")
+        if summary_row:
+            all_records.append(summary_row)
+
+        for record in all_records:
+            growth_day = int(record.get("growth_day", -1))
+            obj, _ = HouseHeaterRuntimeCache.objects.update_or_create(
+                house=house,
+                growth_day=growth_day,
+                defaults={
+                    "record_date": _derive_record_date(house, growth_day),
+                    "is_summary_row": bool(record.get("is_summary_row")),
+                    "total_runtime_minutes": int(record.get("total_runtime_minutes") or 0),
+                    "total_computation_method": record.get("total_computation_method") or "sum_devices",
+                    "per_device_json": record.get("per_device") or {},
+                    "source_timestamp": source_timestamp,
+                    "raw_record_json": record.get("raw_record") or {},
+                },
+            )
+            upserted += 1 if obj else 0
+
+        return {
+            "status": "success",
+            "house_id": house_id,
+            "records_upserted": upserted,
+            "summary_present": bool(summary_row),
+        }
+    except House.DoesNotExist:
+        return {
+            "status": "error",
+            "reason": "house_not_found",
+            "house_id": house_id,
+        }
+    except Exception as exc:
+        logger.error("refresh_house_heater_history failed: %s", exc, exc_info=True)
+        raise self.retry(exc=exc, countdown=30)

--- a/backend/rotem_scraper/tests.py
+++ b/backend/rotem_scraper/tests.py
@@ -1,3 +1,91 @@
+from datetime import date
+from unittest.mock import patch
+
 from django.test import TestCase
 
-# Create your tests here.
+from farms.models import Farm
+from houses.models import House
+from rotem_scraper.models import HouseHeaterRuntimeCache
+from rotem_scraper.scraper import RotemScraper
+from rotem_scraper.tasks import refresh_house_heater_history
+
+
+class Command43ParserTests(TestCase):
+    def test_parse_heater_history_records(self):
+        scraper = RotemScraper("u", "p")
+        payload = {
+            "responseObj": {
+                "dsData": {
+                    "Data": [
+                        {
+                            "HistoryRecord_Heaters_GrowthDay": -1,
+                            "HistoryRecord_Heaters_HeaterDevice_1": "10:00",
+                        },
+                        {
+                            "HistoryRecord_Heaters_GrowthDay": 8,
+                            "HistoryRecord_Heaters_HeaterDevice_1": "04:23",
+                            "HistoryRecord_Heaters_HeaterDevice_2": "01:00",
+                        },
+                    ]
+                }
+            }
+        }
+        out = scraper.parse_heater_history_records(payload)
+        self.assertEqual(len(out["records"]), 1)
+        self.assertIsNotNone(out["summary_row"])
+        record = out["records"][0]
+        self.assertEqual(record["growth_day"], 8)
+        self.assertEqual(record["total_runtime_minutes"], 323)
+        self.assertEqual(record["per_device"]["device_1"]["minutes"], 263)
+        self.assertEqual(record["per_device"]["device_2"]["minutes"], 60)
+
+
+class HeaterHistoryRefreshTaskTests(TestCase):
+    def setUp(self):
+        self.farm = Farm.objects.create(
+            name="Task Farm",
+            location="Loc",
+            contact_person="Owner",
+            contact_phone="000",
+            contact_email="owner@example.com",
+            integration_type="rotem",
+            has_system_integration=True,
+            rotem_username="demo",
+            rotem_password="demo",
+        )
+        self.house = House.objects.create(
+            farm=self.farm,
+            house_number=1,
+            chicken_in_date=date(2026, 1, 1),
+            is_active=True,
+            is_integrated=True,
+        )
+
+    @patch("rotem_scraper.tasks.RotemScraper")
+    def test_refresh_house_heater_history_upserts(self, scraper_cls):
+        scraper = scraper_cls.return_value
+        scraper.login.return_value = True
+        scraper.get_heater_history.return_value = {
+            "source_timestamp": None,
+            "summary_row": {
+                "growth_day": -1,
+                "is_summary_row": True,
+                "total_runtime_minutes": 800,
+                "total_computation_method": "sum_devices",
+                "per_device": {"device_1": {"minutes": 800}},
+                "raw_record": {"HistoryRecord_Heaters_GrowthDay": -1},
+            },
+            "records": [
+                {
+                    "growth_day": 1,
+                    "is_summary_row": False,
+                    "total_runtime_minutes": 120,
+                    "total_computation_method": "sum_devices",
+                    "per_device": {"device_1": {"minutes": 120}},
+                    "raw_record": {"HistoryRecord_Heaters_GrowthDay": 1},
+                }
+            ],
+        }
+        result = refresh_house_heater_history(house_id=self.house.id)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(HouseHeaterRuntimeCache.objects.filter(house=self.house).count(), 2)

--- a/frontend/src/components/houses/HouseDetailPage.tsx
+++ b/frontend/src/components/houses/HouseDetailPage.tsx
@@ -49,6 +49,30 @@ interface HouseDetails {
   monitoring: any;
   alarms: any[];
   stats: any;
+  heater_history?: {
+    summary?: {
+      total_minutes: number;
+      total_hours: number;
+      days_count: number;
+      device_count: number;
+    };
+    daily?: Array<{
+      growth_day: number;
+      date: string | null;
+      total_minutes: number;
+      total_hours: number;
+      total_computation_method: string;
+      per_device: Record<string, { minutes: number; hours: number; raw_value?: string | null }>;
+      last_synced_at: string | null;
+    }>;
+    latest?: any;
+    freshness?: {
+      last_synced_at: string | null;
+      stale: boolean;
+      sync_status: string;
+      stale_after_minutes: number;
+    };
+  };
   tasks?: {
     all: any[];
     today: any[];
@@ -343,6 +367,7 @@ const HouseDetailPage: React.FC = () => {
           monitoring={houseDetails.monitoring}
           alarms={houseDetails.alarms}
           stats={houseDetails.stats}
+          heaterHistory={houseDetails.heater_history}
           onRefresh={loadHouseDetails}
         />
       </TabPanel>

--- a/frontend/src/components/houses/HouseOverviewTab.tsx
+++ b/frontend/src/components/houses/HouseOverviewTab.tsx
@@ -9,6 +9,13 @@ import {
   IconButton,
   Tooltip,
   LinearProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
 } from '@mui/material';
 import {
   Refresh,
@@ -31,6 +38,26 @@ interface HouseOverviewTabProps {
   monitoring: any;
   alarms: any[];
   stats: any;
+  heaterHistory?: {
+    summary?: {
+      total_minutes: number;
+      total_hours: number;
+      days_count: number;
+      device_count: number;
+    };
+    latest?: {
+      growth_day: number;
+      date: string | null;
+      total_minutes: number;
+      total_hours: number;
+      per_device: Record<string, { minutes: number; hours: number }>;
+    } | null;
+    freshness?: {
+      last_synced_at: string | null;
+      stale: boolean;
+      sync_status: string;
+    };
+  };
   onRefresh: () => void;
 }
 
@@ -39,6 +66,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
   monitoring,
   alarms,
   stats,
+  heaterHistory,
   onRefresh,
 }) => {
   const [kpis, setKpis] = useState<HouseMonitoringKpis | null>(null);
@@ -149,6 +177,62 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
               <Typography variant="caption" color="text.secondary">
                 Estimated from status snapshots
               </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                <Typography variant="h6">Heater History (Command 43)</Typography>
+                <Chip
+                  size="small"
+                  color={heaterHistory?.freshness?.stale ? 'warning' : 'success'}
+                  label={heaterHistory?.freshness?.sync_status || 'not_synced'}
+                />
+              </Box>
+              <Typography variant="body2" color="text.secondary" mb={2}>
+                Total: {heaterHistory?.summary?.total_hours ?? 0} h ({heaterHistory?.summary?.days_count ?? 0} days, {heaterHistory?.summary?.device_count ?? 0} devices)
+              </Typography>
+
+              {heaterHistory?.latest ? (
+                <TableContainer component={Paper} variant="outlined">
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Latest Day</TableCell>
+                        <TableCell>Total Hours</TableCell>
+                        <TableCell>Per Device</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <TableRow>
+                        <TableCell>
+                          Day {heaterHistory.latest.growth_day}
+                          {heaterHistory.latest.date ? ` (${heaterHistory.latest.date})` : ''}
+                        </TableCell>
+                        <TableCell>{heaterHistory.latest.total_hours} h</TableCell>
+                        <TableCell>
+                          {Object.entries(heaterHistory.latest.per_device || {}).map(([device, value]) => (
+                            <Chip
+                              key={device}
+                              size="small"
+                              variant="outlined"
+                              sx={{ mr: 0.5, mb: 0.5 }}
+                              label={`${device.replace('_', ' ')}: ${value.hours} h`}
+                            />
+                          ))}
+                        </TableCell>
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Heater runtime history is syncing.
+                </Typography>
+              )}
             </CardContent>
           </Card>
         </Grid>


### PR DESCRIPTION
## Summary
- add CommandID 43 heater-history parsing in the Rotem scraper with robust duration normalization and per-device extraction
- add `HouseHeaterRuntimeCache` storage + migration and an async task to refresh a house's cache from Rotem
- extend `house_details` to return cached heater summary/daily/latest data with freshness metadata, and update house overview UI to show total runtime and per-device latest drill-down
- add backend tests for parser behavior, refresh-task upsert flow, and house-details hybrid cache/refresh behavior

## Test plan
- [x] `docker-compose exec backend python manage.py test rotem_scraper.tests houses.tests.test_house_details_heater_history`
- [ ] Open house detail in UI and verify `Heater History (Command 43)` renders total hours, sync status, and per-device latest-day values
- [ ] Verify missing/stale cache returns immediately and background refresh updates values on subsequent refresh

Made with [Cursor](https://cursor.com)