### PR TITLE
fix(heating): on-demand CommandID 43 heater history (faster house detail)

### DIFF
--- a/backend/houses/services/heater_history_payload.py
+++ b/backend/houses/services/heater_history_payload.py
@@ -1,0 +1,100 @@
+"""Serialize cached CommandID 43 heater history for API responses."""
+from __future__ import annotations
+
+from django.utils import timezone
+
+from rotem_scraper.models import HouseHeaterRuntimeCache
+
+
+def build_heater_history_payload(house) -> dict:
+    """Build heater_history dict from DB cache only (no Rotem calls)."""
+    heater_cache_rows = list(
+        HouseHeaterRuntimeCache.objects.filter(house=house).order_by("growth_day")
+    )
+    now = timezone.now()
+    cache_last_synced_at = max(
+        (row.last_synced_at for row in heater_cache_rows),
+        default=None,
+    )
+    cache_stale_after_minutes = 30
+    is_stale = True
+    if cache_last_synced_at:
+        is_stale = (now - cache_last_synced_at).total_seconds() > (
+            cache_stale_after_minutes * 60
+        )
+
+    sync_status = "fresh"
+    if not heater_cache_rows:
+        sync_status = "missing"
+    elif is_stale:
+        sync_status = "stale"
+
+    summary_row = next((row for row in heater_cache_rows if row.is_summary_row), None)
+    daily_rows = [row for row in heater_cache_rows if not row.is_summary_row]
+
+    def _format_per_device(per_device_json):
+        if not isinstance(per_device_json, dict):
+            return {}
+        out = {}
+        for key, value in per_device_json.items():
+            if isinstance(value, dict):
+                minutes = int(value.get("minutes") or 0)
+                out[key] = {
+                    "minutes": minutes,
+                    "hours": round(minutes / 60.0, 2),
+                    "raw_value": value.get("raw_value"),
+                }
+            else:
+                minutes = int(value or 0)
+                out[key] = {
+                    "minutes": minutes,
+                    "hours": round(minutes / 60.0, 2),
+                    "raw_value": None,
+                }
+        return out
+
+    daily_payload = []
+    for row in daily_rows:
+        daily_payload.append(
+            {
+                "growth_day": row.growth_day,
+                "date": row.record_date.isoformat() if row.record_date else None,
+                "total_minutes": row.total_runtime_minutes,
+                "total_hours": round(row.total_runtime_minutes / 60.0, 2),
+                "total_computation_method": row.total_computation_method,
+                "per_device": _format_per_device(row.per_device_json),
+                "last_synced_at": row.last_synced_at.isoformat()
+                if row.last_synced_at
+                else None,
+            }
+        )
+
+    summary_minutes = sum(item["total_minutes"] for item in daily_payload)
+    device_keys = set()
+    for item in daily_payload:
+        device_keys.update(item["per_device"].keys())
+
+    return {
+        "summary": {
+            "total_minutes": summary_minutes,
+            "total_hours": round(summary_minutes / 60.0, 2),
+            "days_count": len(daily_payload),
+            "device_count": len(device_keys),
+            "summary_row_minutes": summary_row.total_runtime_minutes
+            if summary_row
+            else None,
+            "summary_row_hours": round(summary_row.total_runtime_minutes / 60.0, 2)
+            if summary_row
+            else None,
+        },
+        "daily": daily_payload,
+        "latest": daily_payload[-1] if daily_payload else None,
+        "freshness": {
+            "last_synced_at": cache_last_synced_at.isoformat()
+            if cache_last_synced_at
+            else None,
+            "stale": is_stale if heater_cache_rows else True,
+            "sync_status": sync_status,
+            "stale_after_minutes": cache_stale_after_minutes,
+        },
+    }

--- a/backend/houses/tests/test_house_details_heater_history.py
+++ b/backend/houses/tests/test_house_details_heater_history.py
@@ -12,7 +12,7 @@ from houses.models import House
 from rotem_scraper.models import HouseHeaterRuntimeCache
 
 
-class HouseDetailsHeaterHistoryTests(TestCase):
+class HouseHeaterHistoryApiTests(TestCase):
     def setUp(self):
         self.client = APIClient()
         user_model = get_user_model()
@@ -45,8 +45,14 @@ class HouseDetailsHeaterHistoryTests(TestCase):
             is_integrated=True,
         )
 
-    @patch("houses.views.refresh_house_heater_history.delay")
-    def test_house_details_returns_cached_heater_history(self, mock_delay):
+    def test_house_details_does_not_include_heater_history(self):
+        response = self.client.get(
+            reverse("house-details", kwargs={"house_id": self.house.id})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("heater_history", response.json())
+
+    def test_get_heater_history_returns_cache(self):
         HouseHeaterRuntimeCache.objects.create(
             house=self.house,
             growth_day=10,
@@ -59,20 +65,31 @@ class HouseDetailsHeaterHistoryTests(TestCase):
             last_synced_at=timezone.now()
         )
 
-        response = self.client.get(reverse("house-details", kwargs={"house_id": self.house.id}))
+        response = self.client.get(
+            reverse("house-heater-history", kwargs={"house_id": self.house.id})
+        )
         self.assertEqual(response.status_code, 200)
         payload = response.json()
-        self.assertIn("heater_history", payload)
         self.assertEqual(payload["heater_history"]["summary"]["total_minutes"], 180)
         self.assertEqual(payload["heater_history"]["daily"][0]["growth_day"], 10)
-        self.assertIn(payload["heater_history"]["freshness"]["sync_status"], ["fresh", "refreshing"])
-        mock_delay.assert_not_called()
 
-    @patch("houses.views.refresh_house_heater_history.delay")
-    def test_house_details_triggers_refresh_when_cache_missing(self, mock_delay):
-        response = self.client.get(reverse("house-details", kwargs={"house_id": self.house.id}))
+    @patch("houses.views.sync_refresh_house_heater_history")
+    def test_post_refresh_returns_payload(self, mock_sync):
+        mock_sync.return_value = {"status": "success", "house_id": self.house.id}
+        HouseHeaterRuntimeCache.objects.create(
+            house=self.house,
+            growth_day=1,
+            record_date=date.today(),
+            total_runtime_minutes=60,
+            per_device_json={"device_1": {"minutes": 60}},
+            raw_record_json={},
+        )
+
+        response = self.client.post(
+            reverse(
+                "house-heater-history-refresh", kwargs={"house_id": self.house.id}
+            )
+        )
         self.assertEqual(response.status_code, 200)
-        payload = response.json()
-        self.assertEqual(payload["heater_history"]["daily"], [])
-        self.assertEqual(payload["heater_history"]["freshness"]["sync_status"], "refreshing")
-        mock_delay.assert_called_once_with(self.house.id)
+        self.assertIn("heater_history", response.json())
+        mock_sync.assert_called_once_with(self.house.id)

--- a/backend/houses/urls.py
+++ b/backend/houses/urls.py
@@ -23,6 +23,16 @@ urlpatterns = [
     # Detailed house information
     path('houses/<int:house_id>/details/', views.house_details, name='house-details'),
     path(
+        'houses/<int:house_id>/heater-history/',
+        views.house_heater_history,
+        name='house-heater-history',
+    ),
+    path(
+        'houses/<int:house_id>/heater-history/refresh/',
+        views.house_heater_history_refresh,
+        name='house-heater-history-refresh',
+    ),
+    path(
         'houses/<int:house_id>/flocks/sync-from-rotem/',
         views.sync_flock_from_rotem,
         name='house-flocks-sync-from-rotem',

--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -36,8 +36,8 @@ from tasks.serializers import TaskSerializer
 from collections import defaultdict
 from .services.water_forecast_service import WaterForecastService
 from .services.monitoring_contract import MonitoringUnits
-from rotem_scraper.models import HouseHeaterRuntimeCache
-from rotem_scraper.tasks import refresh_house_heater_history
+from .services.heater_history_payload import build_heater_history_payload
+from rotem_scraper.tasks import sync_refresh_house_heater_history
 
 
 class HouseListCreateView(generics.ListCreateAPIView):
@@ -586,101 +586,12 @@ def house_details(request, house_id):
         else:
             upcoming_tasks.append(task)
     
-    heater_cache_rows = list(
-        HouseHeaterRuntimeCache.objects.filter(house=house).order_by("growth_day")
-    )
-    now = timezone.now()
-    cache_last_synced_at = max(
-        (row.last_synced_at for row in heater_cache_rows),
-        default=None,
-    )
-    cache_stale_after_minutes = 30
-    is_stale = True
-    if cache_last_synced_at:
-        is_stale = (now - cache_last_synced_at).total_seconds() > (cache_stale_after_minutes * 60)
-
-    sync_status = "fresh"
-    if not heater_cache_rows:
-        sync_status = "missing"
-    elif is_stale:
-        sync_status = "stale"
-
-    # Fire-and-forget refresh when cache is missing/stale.
-    if sync_status in {"missing", "stale"}:
-        try:
-            refresh_house_heater_history.delay(house.id)
-            sync_status = "refreshing"
-        except Exception:
-            # Keep response non-blocking even if broker is unavailable.
-            pass
-
-    summary_row = next((row for row in heater_cache_rows if row.is_summary_row), None)
-    daily_rows = [row for row in heater_cache_rows if not row.is_summary_row]
-
-    def _format_per_device(per_device_json):
-        if not isinstance(per_device_json, dict):
-            return {}
-        out = {}
-        for key, value in per_device_json.items():
-            if isinstance(value, dict):
-                minutes = int(value.get("minutes") or 0)
-                out[key] = {
-                    "minutes": minutes,
-                    "hours": round(minutes / 60.0, 2),
-                    "raw_value": value.get("raw_value"),
-                }
-            else:
-                minutes = int(value or 0)
-                out[key] = {
-                    "minutes": minutes,
-                    "hours": round(minutes / 60.0, 2),
-                    "raw_value": None,
-                }
-        return out
-
-    daily_payload = []
-    for row in daily_rows:
-        daily_payload.append({
-            "growth_day": row.growth_day,
-            "date": row.record_date.isoformat() if row.record_date else None,
-            "total_minutes": row.total_runtime_minutes,
-            "total_hours": round(row.total_runtime_minutes / 60.0, 2),
-            "total_computation_method": row.total_computation_method,
-            "per_device": _format_per_device(row.per_device_json),
-            "last_synced_at": row.last_synced_at.isoformat() if row.last_synced_at else None,
-        })
-
-    summary_minutes = sum(item["total_minutes"] for item in daily_payload)
-    device_keys = set()
-    for item in daily_payload:
-        device_keys.update(item["per_device"].keys())
-
-    heater_history = {
-        "summary": {
-            "total_minutes": summary_minutes,
-            "total_hours": round(summary_minutes / 60.0, 2),
-            "days_count": len(daily_payload),
-            "device_count": len(device_keys),
-            "summary_row_minutes": summary_row.total_runtime_minutes if summary_row else None,
-            "summary_row_hours": round(summary_row.total_runtime_minutes / 60.0, 2) if summary_row else None,
-        },
-        "daily": daily_payload,
-        "latest": daily_payload[-1] if daily_payload else None,
-        "freshness": {
-            "last_synced_at": cache_last_synced_at.isoformat() if cache_last_synced_at else None,
-            "stale": is_stale if heater_cache_rows else True,
-            "sync_status": sync_status,
-            "stale_after_minutes": cache_stale_after_minutes,
-        },
-    }
-
-    # Build comprehensive response
+    # Build comprehensive response (heater CommandID 43 history: load via dedicated endpoints on demand)
     details = {
         'house': HouseSerializer(house).data,
         'monitoring': HouseMonitoringSnapshotSerializer(snapshot).data if snapshot else None,
         'alarms': HouseAlarmSerializer(active_alarms, many=True).data,
         'stats': house.get_stats(days=7) if snapshot else None,
-        'heater_history': heater_history,
         'tasks': {
             'all': TaskSerializer(tasks, many=True).data,
             'today': TaskSerializer(today_tasks, many=True).data,
@@ -694,6 +605,36 @@ def house_details(request, house_id):
     }
     
     return Response(details)
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def house_heater_history(request, house_id):
+    """Cached CommandID 43 heater history only (fast; no Rotem call)."""
+    house = get_object_or_404(House, id=house_id)
+    return Response({"heater_history": build_heater_history_payload(house)})
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def house_heater_history_refresh(request, house_id):
+    """Fetch CommandID 43 from Rotem, update cache, return serialized heater history."""
+    house = get_object_or_404(House, id=house_id)
+    result = sync_refresh_house_heater_history(house.id)
+    if result.get("status") == "success":
+        return Response(
+            {
+                "heater_history": build_heater_history_payload(house),
+                "refresh_result": result,
+            }
+        )
+    status_code = status.HTTP_400_BAD_REQUEST
+    if result.get("reason") in ("login_failed", "empty_response"):
+        status_code = status.HTTP_502_BAD_GATEWAY
+    return Response(
+        {"error": result.get("reason", "refresh_failed"), "refresh_result": result},
+        status=status_code,
+    )
 
 
 @api_view(['GET'])

--- a/backend/rotem_scraper/tasks.py
+++ b/backend/rotem_scraper/tasks.py
@@ -194,9 +194,11 @@ def collect_monitoring_data(self, farm_id=None):
         raise self.retry(exc=exc, countdown=300)  # Retry after 5 minutes
 
 
-@shared_task(bind=True, max_retries=2)
-def refresh_house_heater_history(self, house_id: int):
-    """Refresh cached house heater runtime history from Rotem CommandID 43."""
+def sync_refresh_house_heater_history(house_id: int) -> dict:
+    """
+    Fetch CommandID 43 heater history from Rotem and upsert cache.
+    Safe to call synchronously from an API view (user-initiated load).
+    """
     try:
         house = House.objects.select_related("farm").get(id=house_id)
         farm = house.farm
@@ -233,20 +235,21 @@ def refresh_house_heater_history(self, house_id: int):
 
         for record in all_records:
             growth_day = int(record.get("growth_day", -1))
-            obj, _ = HouseHeaterRuntimeCache.objects.update_or_create(
+            _, _ = HouseHeaterRuntimeCache.objects.update_or_create(
                 house=house,
                 growth_day=growth_day,
                 defaults={
                     "record_date": _derive_record_date(house, growth_day),
                     "is_summary_row": bool(record.get("is_summary_row")),
                     "total_runtime_minutes": int(record.get("total_runtime_minutes") or 0),
-                    "total_computation_method": record.get("total_computation_method") or "sum_devices",
+                    "total_computation_method": record.get("total_computation_method")
+                    or "sum_devices",
                     "per_device_json": record.get("per_device") or {},
                     "source_timestamp": source_timestamp,
                     "raw_record_json": record.get("raw_record") or {},
                 },
             )
-            upserted += 1 if obj else 0
+            upserted += 1
 
         return {
             "status": "success",
@@ -260,6 +263,13 @@ def refresh_house_heater_history(self, house_id: int):
             "reason": "house_not_found",
             "house_id": house_id,
         }
+
+
+@shared_task(bind=True, max_retries=2)
+def refresh_house_heater_history(self, house_id: int):
+    """Celery wrapper for background refresh (optional; on-demand uses sync_refresh)."""
+    try:
+        return sync_refresh_house_heater_history(house_id)
     except Exception as exc:
         logger.error("refresh_house_heater_history failed: %s", exc, exc_info=True)
         raise self.retry(exc=exc, countdown=30)

--- a/backend/rotem_scraper/tests.py
+++ b/backend/rotem_scraper/tests.py
@@ -7,7 +7,7 @@ from farms.models import Farm
 from houses.models import House
 from rotem_scraper.models import HouseHeaterRuntimeCache
 from rotem_scraper.scraper import RotemScraper
-from rotem_scraper.tasks import refresh_house_heater_history
+from rotem_scraper.tasks import sync_refresh_house_heater_history
 
 
 class Command43ParserTests(TestCase):
@@ -86,6 +86,6 @@ class HeaterHistoryRefreshTaskTests(TestCase):
                 }
             ],
         }
-        result = refresh_house_heater_history(house_id=self.house.id)
+        result = sync_refresh_house_heater_history(self.house.id)
         self.assertEqual(result["status"], "success")
         self.assertEqual(HouseHeaterRuntimeCache.objects.filter(house=self.house).count(), 2)

--- a/frontend/src/components/houses/HouseDetailPage.tsx
+++ b/frontend/src/components/houses/HouseDetailPage.tsx
@@ -49,30 +49,6 @@ interface HouseDetails {
   monitoring: any;
   alarms: any[];
   stats: any;
-  heater_history?: {
-    summary?: {
-      total_minutes: number;
-      total_hours: number;
-      days_count: number;
-      device_count: number;
-    };
-    daily?: Array<{
-      growth_day: number;
-      date: string | null;
-      total_minutes: number;
-      total_hours: number;
-      total_computation_method: string;
-      per_device: Record<string, { minutes: number; hours: number; raw_value?: string | null }>;
-      last_synced_at: string | null;
-    }>;
-    latest?: any;
-    freshness?: {
-      last_synced_at: string | null;
-      stale: boolean;
-      sync_status: string;
-      stale_after_minutes: number;
-    };
-  };
   tasks?: {
     all: any[];
     today: any[];
@@ -367,7 +343,6 @@ const HouseDetailPage: React.FC = () => {
           monitoring={houseDetails.monitoring}
           alarms={houseDetails.alarms}
           stats={houseDetails.stats}
-          heaterHistory={houseDetails.heater_history}
           onRefresh={loadHouseDetails}
         />
       </TabPanel>

--- a/frontend/src/components/houses/HouseOverviewTab.tsx
+++ b/frontend/src/components/houses/HouseOverviewTab.tsx
@@ -16,6 +16,9 @@ import {
   TableHead,
   TableRow,
   Paper,
+  Button,
+  CircularProgress,
+  Alert,
 } from '@mui/material';
 import {
   Refresh,
@@ -38,26 +41,6 @@ interface HouseOverviewTabProps {
   monitoring: any;
   alarms: any[];
   stats: any;
-  heaterHistory?: {
-    summary?: {
-      total_minutes: number;
-      total_hours: number;
-      days_count: number;
-      device_count: number;
-    };
-    latest?: {
-      growth_day: number;
-      date: string | null;
-      total_minutes: number;
-      total_hours: number;
-      per_device: Record<string, { minutes: number; hours: number }>;
-    } | null;
-    freshness?: {
-      last_synced_at: string | null;
-      stale: boolean;
-      sync_status: string;
-    };
-  };
   onRefresh: () => void;
 }
 
@@ -66,11 +49,14 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
   monitoring,
   alarms,
   stats,
-  heaterHistory,
   onRefresh,
 }) => {
   const [kpis, setKpis] = useState<HouseMonitoringKpis | null>(null);
   const [kpiLoading, setKpiLoading] = useState(false);
+  const [heaterHistory, setHeaterHistory] = useState<any>(null);
+  const [heaterRotemLoading, setHeaterRotemLoading] = useState(false);
+  const [heaterCacheLoading, setHeaterCacheLoading] = useState(false);
+  const [heaterError, setHeaterError] = useState<string | null>(null);
 
   useEffect(() => {
     const loadKpis = async () => {
@@ -88,6 +74,39 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
     };
     loadKpis();
   }, [house?.id, monitoring?.timestamp]);
+
+  const loadHeaterHistoryCached = async () => {
+    if (!house?.id) return;
+    try {
+      setHeaterCacheLoading(true);
+      setHeaterError(null);
+      const data = await monitoringApi.getHouseHeaterHistory(house.id);
+      setHeaterHistory(data.heater_history);
+    } catch (error) {
+      console.error('Failed to load cached heater history:', error);
+      setHeaterError('Could not load saved heater history.');
+    } finally {
+      setHeaterCacheLoading(false);
+    }
+  };
+
+  const fetchHeaterHistoryFromRotem = async () => {
+    if (!house?.id) return;
+    try {
+      setHeaterRotemLoading(true);
+      setHeaterError(null);
+      const data = await monitoringApi.refreshHouseHeaterHistory(house.id);
+      setHeaterHistory(data.heater_history);
+    } catch (error: any) {
+      const msg =
+        error?.response?.data?.error ||
+        error?.response?.data?.detail ||
+        'Failed to fetch heater history from Rotem.';
+      setHeaterError(typeof msg === 'string' ? msg : 'Failed to fetch heater history from Rotem.');
+    } finally {
+      setHeaterRotemLoading(false);
+    }
+  };
 
   const getTrendColor = (deltaPct: number | null | undefined): 'success' | 'warning' | 'error' | 'default' => {
     if (deltaPct === null || deltaPct === undefined) return 'default';
@@ -184,16 +203,49 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
         <Grid item xs={12}>
           <Card>
             <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+              <Box display="flex" flexWrap="wrap" justifyContent="space-between" alignItems="center" gap={1} mb={1}>
                 <Typography variant="h6">Heater History (Command 43)</Typography>
-                <Chip
-                  size="small"
-                  color={heaterHistory?.freshness?.stale ? 'warning' : 'success'}
-                  label={heaterHistory?.freshness?.sync_status || 'not_synced'}
-                />
+                <Box display="flex" flexWrap="wrap" gap={1} alignItems="center">
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={loadHeaterHistoryCached}
+                    disabled={heaterCacheLoading || heaterRotemLoading}
+                    startIcon={heaterCacheLoading ? <CircularProgress size={16} /> : undefined}
+                  >
+                    Load saved
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    onClick={fetchHeaterHistoryFromRotem}
+                    disabled={heaterRotemLoading}
+                    startIcon={heaterRotemLoading ? <CircularProgress size={16} color="inherit" /> : undefined}
+                  >
+                    Fetch from Rotem
+                  </Button>
+                  {heaterHistory?.freshness?.sync_status ? (
+                    <Chip
+                      size="small"
+                      color={heaterHistory?.freshness?.stale ? 'warning' : 'success'}
+                      label={heaterHistory.freshness.sync_status}
+                    />
+                  ) : null}
+                </Box>
               </Box>
+              <Typography variant="body2" color="text.secondary" mb={1}>
+                Not loaded with the page. Use the buttons above so the house overview stays fast.
+              </Typography>
+              {heaterError && (
+                <Alert severity="error" sx={{ mb: 1 }} onClose={() => setHeaterError(null)}>
+                  {heaterError}
+                </Alert>
+              )}
+              {heaterRotemLoading && <LinearProgress sx={{ mb: 1 }} />}
               <Typography variant="body2" color="text.secondary" mb={2}>
-                Total: {heaterHistory?.summary?.total_hours ?? 0} h ({heaterHistory?.summary?.days_count ?? 0} days, {heaterHistory?.summary?.device_count ?? 0} devices)
+                Total: {heaterHistory?.summary?.total_hours ?? '—'} h (
+                {heaterHistory?.summary?.days_count ?? 0} days, {heaterHistory?.summary?.device_count ?? 0}{' '}
+                devices)
               </Typography>
 
               {heaterHistory?.latest ? (
@@ -214,7 +266,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                         </TableCell>
                         <TableCell>{heaterHistory.latest.total_hours} h</TableCell>
                         <TableCell>
-                          {Object.entries(heaterHistory.latest.per_device || {}).map(([device, value]) => (
+                          {Object.entries(heaterHistory.latest.per_device || {}).map(([device, value]: [string, any]) => (
                             <Chip
                               key={device}
                               size="small"
@@ -230,7 +282,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                 </TableContainer>
               ) : (
                 <Typography variant="body2" color="text.secondary">
-                  Heater runtime history is syncing.
+                  Click &quot;Load saved&quot; or &quot;Fetch from Rotem&quot; to show heater runtime by day.
                 </Typography>
               )}
             </CardContent>

--- a/frontend/src/services/monitoringApi.ts
+++ b/frontend/src/services/monitoringApi.ts
@@ -138,6 +138,31 @@ class MonitoringApiService {
     });
     return response.data;
   }
+
+  /**
+   * Cached CommandID 43 heater history only (fast; no Rotem call).
+   */
+  async getHouseHeaterHistory(houseId: number): Promise<{ heater_history: Record<string, unknown> }> {
+    const response = await api.get(`/houses/${houseId}/heater-history/`, {
+      headers: this.getAuthHeaders(),
+    });
+    return response.data;
+  }
+
+  /**
+   * Fetch CommandID 43 from Rotem and return updated heater history.
+   */
+  async refreshHouseHeaterHistory(houseId: number): Promise<{
+    heater_history: Record<string, unknown>;
+    refresh_result?: Record<string, unknown>;
+  }> {
+    const response = await api.post(
+      `/houses/${houseId}/heater-history/refresh/`,
+      {},
+      { headers: this.getAuthHeaders() }
+    );
+    return response.data;
+  }
 }
 
 const monitoringApiService = new MonitoringApiService();


### PR DESCRIPTION
## Summary
- Remove `heater_history` from `GET /houses/<id>/details/` so the house detail page stays fast and does not trigger Rotem/Celery on load.
- Add `GET /houses/<id>/heater-history/` (cache only) and `POST /houses/<id>/heater-history/refresh/` (sync Command 43, return payload).
- Refactor payload building into `houses/services/heater_history_payload.py`; Celery task delegates to `sync_refresh_house_heater_history`.
- House overview: load heater history only via **Load saved** / **Fetch from Rotem** with inline loading in the card.

## Test plan
- [x] `docker-compose exec backend python manage.py test houses.tests.test_house_details_heater_history rotem_scraper.tests`

Made with [Cursor](https://cursor.com)