### PR TITLE
feat(monitoring): heater history day selection and DOD KPI by date

### DIFF
--- a/backend/houses/tests/test_house_monitoring_kpis.py
+++ b/backend/houses/tests/test_house_monitoring_kpis.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -116,6 +116,7 @@ class HouseMonitoringKpisApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
 
+        self.assertIsNone(data.get("day_over_day_context"))
         self.assertEqual(data["house_id"], self.house.id)
         self.assertEqual(data["water_day_over_day"]["current"], 150.0)
         self.assertEqual(data["water_day_over_day"]["previous"], 120.0)
@@ -146,3 +147,47 @@ class HouseMonitoringKpisApiTests(TestCase):
         self.assertIsNone(data["water_day_over_day"]["delta"])
         self.assertIsNone(data["feed_day_over_day"]["delta"])
         self.assertFalse(data["data_quality"]["enough_for_dod_delta"])
+
+    def test_dod_reference_date_outside_rolling_7d_window(self):
+        """Historical calendar days must resolve via timestamp__date, not only snapshots_7d."""
+        now = timezone.now()
+        ref_date = (now.date() - timedelta(days=10))
+        prev_date = ref_date - timedelta(days=1)
+
+        self._create_snapshot(
+            timestamp=timezone.make_aware(datetime.combine(prev_date, time(8, 0))),
+            water=100,
+            feed=200,
+            heater_on=False,
+            fan_on=False,
+        )
+        self._create_snapshot(
+            timestamp=timezone.make_aware(datetime.combine(ref_date, time(12, 0))),
+            water=155,
+            feed=290,
+            heater_on=False,
+            fan_on=False,
+        )
+
+        url = reverse("house-monitoring-kpis", kwargs={"house_id": self.house.id})
+        response = self.client.get(url, {"dod_reference_date": ref_date.isoformat()})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertEqual(
+            data["day_over_day_context"],
+            {"reference_date": ref_date.isoformat(), "compare_date": prev_date.isoformat()},
+        )
+        self.assertEqual(data["water_day_over_day"]["current"], 155.0)
+        self.assertEqual(data["water_day_over_day"]["previous"], 100.0)
+        self.assertEqual(data["water_day_over_day"]["delta"], 55.0)
+        self.assertEqual(data["feed_day_over_day"]["current"], 290.0)
+        self.assertEqual(data["feed_day_over_day"]["previous"], 200.0)
+        self.assertEqual(data["feed_day_over_day"]["delta"], 90.0)
+        self.assertTrue(data["data_quality"]["enough_for_dod_delta"])
+
+    def test_invalid_dod_reference_date_returns_400(self):
+        url = reverse("house-monitoring-kpis", kwargs={"house_id": self.house.id})
+        response = self.client.get(url, {"dod_reference_date": "not-a-date"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("detail", response.json())

--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
 from django.db.models import Q, Avg, Max, Min
 from django.utils import timezone
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, date
 from .models import (
     House,
     HouseMonitoringSnapshot,
@@ -321,29 +321,59 @@ def house_monitoring_kpis(request, house_id):
         ).order_by('-timestamp')
     )
 
-    # Build day buckets for day-over-day deltas.
-    day_water = defaultdict(list)
-    day_feed = defaultdict(list)
-    for snap in snapshots_7d:
-        day_key = snap.timestamp.date().isoformat()
-        if snap.water_consumption is not None:
-            day_water[day_key].append(float(snap.water_consumption))
-        if snap.feed_consumption is not None:
-            day_feed[day_key].append(float(snap.feed_consumption))
+    dod_param = request.query_params.get('dod_reference_date')
+    day_over_day_context = None
 
-    def daily_value(day_map, day):
-        values = day_map.get(day, [])
-        if not values:
-            return None
-        # Use max as daily total proxy to avoid underestimating during intra-day refreshes.
-        return max(values)
+    def max_metric_on_calendar_day(metric_field: str, d: date):
+        """Max snapshot value for a calendar day (same proxy as daily_value max)."""
+        agg = HouseMonitoringSnapshot.objects.filter(
+            house=house,
+            timestamp__date=d,
+        ).aggregate(m=Max(metric_field))
+        v = agg['m']
+        return float(v) if v is not None else None
 
-    today_key = now.date().isoformat()
-    yesterday_key = (now.date() - timedelta(days=1)).isoformat()
-    water_today = daily_value(day_water, today_key)
-    water_yesterday = daily_value(day_water, yesterday_key)
-    feed_today = daily_value(day_feed, today_key)
-    feed_yesterday = daily_value(day_feed, yesterday_key)
+    if dod_param:
+        try:
+            ref_d = date.fromisoformat(dod_param.strip())
+        except ValueError:
+            return Response(
+                {'detail': 'Invalid dod_reference_date; expected YYYY-MM-DD.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        prev_d = ref_d - timedelta(days=1)
+        day_over_day_context = {
+            'reference_date': ref_d.isoformat(),
+            'compare_date': prev_d.isoformat(),
+        }
+        water_today = max_metric_on_calendar_day('water_consumption', ref_d)
+        water_yesterday = max_metric_on_calendar_day('water_consumption', prev_d)
+        feed_today = max_metric_on_calendar_day('feed_consumption', ref_d)
+        feed_yesterday = max_metric_on_calendar_day('feed_consumption', prev_d)
+    else:
+        # Build day buckets for day-over-day deltas (rolling 7d window).
+        day_water = defaultdict(list)
+        day_feed = defaultdict(list)
+        for snap in snapshots_7d:
+            day_key = snap.timestamp.date().isoformat()
+            if snap.water_consumption is not None:
+                day_water[day_key].append(float(snap.water_consumption))
+            if snap.feed_consumption is not None:
+                day_feed[day_key].append(float(snap.feed_consumption))
+
+        def daily_value(day_map, day):
+            values = day_map.get(day, [])
+            if not values:
+                return None
+            # Use max as daily total proxy to avoid underestimating during intra-day refreshes.
+            return max(values)
+
+        today_key = now.date().isoformat()
+        yesterday_key = (now.date() - timedelta(days=1)).isoformat()
+        water_today = daily_value(day_water, today_key)
+        water_yesterday = daily_value(day_water, yesterday_key)
+        feed_today = daily_value(day_feed, today_key)
+        feed_yesterday = daily_value(day_feed, yesterday_key)
 
     def calc_delta(current, previous):
         if current is None or previous is None:
@@ -430,6 +460,7 @@ def house_monitoring_kpis(request, house_id):
     response = {
         'house_id': house.id,
         'window_hours': 24,
+        'day_over_day_context': day_over_day_context,
         'data_quality': {
             'snapshots_24h': len(snapshots_24h),
             'snapshots_7d': len(snapshots_7d),

--- a/frontend/src/components/houses/HouseOverviewTab.tsx
+++ b/frontend/src/components/houses/HouseOverviewTab.tsx
@@ -36,6 +36,25 @@ import {
 import monitoringApi from '../../services/monitoringApi';
 import { HouseMonitoringKpis } from '../../types/monitoring';
 
+/** Command 43 heater history daily row (API `heater_history.daily`). */
+interface HeaterHistoryDailyRow {
+  growth_day: number;
+  date: string | null;
+  total_hours: number;
+  per_device: Record<string, { hours: number; minutes?: number; raw_value?: unknown }>;
+}
+
+function formatShortCalendarDate(isoDate: string): string {
+  const parts = isoDate.split('-').map((s) => parseInt(s, 10));
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) return isoDate;
+  const [y, m, d] = parts;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: y !== new Date().getFullYear() ? 'numeric' : undefined,
+  });
+}
+
 interface HouseOverviewTabProps {
   house: any;
   monitoring: any;
@@ -57,13 +76,24 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
   const [heaterRotemLoading, setHeaterRotemLoading] = useState(false);
   const [heaterCacheLoading, setHeaterCacheLoading] = useState(false);
   const [heaterError, setHeaterError] = useState<string | null>(null);
+  const [dodReferenceDate, setDodReferenceDate] = useState<string | null>(null);
+  const [selectedHeaterGrowthDay, setSelectedHeaterGrowthDay] = useState<number | null>(null);
+
+  useEffect(() => {
+    setDodReferenceDate(null);
+    setSelectedHeaterGrowthDay(null);
+    setHeaterHistory(null);
+    setHeaterError(null);
+  }, [house?.id]);
 
   useEffect(() => {
     const loadKpis = async () => {
       if (!house?.id) return;
       try {
         setKpiLoading(true);
-        const result = await monitoringApi.getHouseMonitoringKpis(house.id);
+        const result = await monitoringApi.getHouseMonitoringKpis(house.id, {
+          dodReferenceDate: dodReferenceDate ?? undefined,
+        });
         setKpis(result);
       } catch (error) {
         console.error('Failed to load house monitoring KPIs:', error);
@@ -73,7 +103,20 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
       }
     };
     loadKpis();
-  }, [house?.id, monitoring?.timestamp]);
+  }, [house?.id, monitoring?.timestamp, dodReferenceDate]);
+
+  const applyHeaterHistoryPayload = (hist: Record<string, unknown>) => {
+    setHeaterHistory(hist);
+    const daily = hist?.daily as HeaterHistoryDailyRow[] | undefined;
+    if (daily && daily.length > 0) {
+      const last = daily[daily.length - 1];
+      setSelectedHeaterGrowthDay(last.growth_day);
+      setDodReferenceDate(typeof last.date === 'string' ? last.date : null);
+    } else {
+      setSelectedHeaterGrowthDay(null);
+      setDodReferenceDate(null);
+    }
+  };
 
   const loadHeaterHistoryCached = async () => {
     if (!house?.id) return;
@@ -81,7 +124,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
       setHeaterCacheLoading(true);
       setHeaterError(null);
       const data = await monitoringApi.getHouseHeaterHistory(house.id);
-      setHeaterHistory(data.heater_history);
+      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>);
     } catch (error) {
       console.error('Failed to load cached heater history:', error);
       setHeaterError('Could not load saved heater history.');
@@ -96,7 +139,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
       setHeaterRotemLoading(true);
       setHeaterError(null);
       const data = await monitoringApi.refreshHouseHeaterHistory(house.id);
-      setHeaterHistory(data.heater_history);
+      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>);
     } catch (error: any) {
       const msg =
         error?.response?.data?.error ||
@@ -152,6 +195,29 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
     }
   };
 
+  const formatDodCaption = (
+    current: number | null | undefined,
+    previous: number | null | undefined,
+    unit: string
+  ): string => {
+    const ctx = kpis?.day_over_day_context;
+    const curTitle = ctx?.reference_date ? formatShortCalendarDate(ctx.reference_date) : 'Today';
+    const prevTitle = ctx?.compare_date ? formatShortCalendarDate(ctx.compare_date) : 'Yesterday';
+    const fmt = (v: number | null | undefined) =>
+      v != null && !Number.isNaN(v) ? v.toFixed(1) : 'N/A';
+    return `${curTitle}: ${fmt(current)}${unit} | ${prevTitle}: ${fmt(previous)}${unit}`;
+  };
+
+  const heaterDaily: HeaterHistoryDailyRow[] = Array.isArray(
+    (heaterHistory as { daily?: HeaterHistoryDailyRow[] } | null)?.daily
+  )
+    ? ((heaterHistory as { daily: HeaterHistoryDailyRow[] }).daily)
+    : [];
+  const selectedHeaterRow =
+    selectedHeaterGrowthDay != null
+      ? heaterDaily.find((r) => r.growth_day === selectedHeaterGrowthDay)
+      : undefined;
+
   if (!monitoring) {
     return (
       <Box textAlign="center" py={4}>
@@ -201,7 +267,14 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
         </Grid>
 
         <Grid item xs={12}>
-          <Card>
+          <Card
+            variant="outlined"
+            sx={{
+              borderRadius: 2,
+              boxShadow: 1,
+              bgcolor: 'background.paper',
+            }}
+          >
             <CardContent>
               <Box display="flex" flexWrap="wrap" justifyContent="space-between" alignItems="center" gap={1} mb={1}>
                 <Typography variant="h6">Heater History (Command 43)</Typography>
@@ -234,7 +307,8 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                 </Box>
               </Box>
               <Typography variant="body2" color="text.secondary" mb={1}>
-                Not loaded with the page. Use the buttons above so the house overview stays fast.
+                Not loaded with the page. Use the buttons above so the house overview stays fast. Select a row to
+                align water/feed day-over-day with that calendar day (when a date is present).
               </Typography>
               {heaterError && (
                 <Alert severity="error" sx={{ mb: 1 }} onClose={() => setHeaterError(null)}>
@@ -248,38 +322,94 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                 devices)
               </Typography>
 
-              {heaterHistory?.latest ? (
-                <TableContainer component={Paper} variant="outlined">
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Latest Day</TableCell>
-                        <TableCell>Total Hours</TableCell>
-                        <TableCell>Per Device</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      <TableRow>
-                        <TableCell>
-                          Day {heaterHistory.latest.growth_day}
-                          {heaterHistory.latest.date ? ` (${heaterHistory.latest.date})` : ''}
-                        </TableCell>
-                        <TableCell>{heaterHistory.latest.total_hours} h</TableCell>
-                        <TableCell>
-                          {Object.entries(heaterHistory.latest.per_device || {}).map(([device, value]: [string, any]) => (
-                            <Chip
-                              key={device}
-                              size="small"
-                              variant="outlined"
-                              sx={{ mr: 0.5, mb: 0.5 }}
-                              label={`${device.replace('_', ' ')}: ${value.hours} h`}
-                            />
-                          ))}
-                        </TableCell>
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                </TableContainer>
+              {heaterDaily.length > 0 ? (
+                <>
+                  <TableContainer
+                    component={Paper}
+                    variant="outlined"
+                    sx={{
+                      maxHeight: 320,
+                      borderRadius: 1,
+                      '& .MuiTableCell-head': {
+                        bgcolor: 'action.hover',
+                        fontWeight: 600,
+                        whiteSpace: 'nowrap',
+                      },
+                    }}
+                  >
+                    <Table size="small" stickyHeader>
+                      <TableHead>
+                        <TableRow>
+                          <TableCell>Growth day</TableCell>
+                          <TableCell>Date</TableCell>
+                          <TableCell align="right">Total</TableCell>
+                          <TableCell>Devices (summary)</TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {heaterDaily.map((row) => {
+                          const deviceSummary = Object.entries(row.per_device || {})
+                            .map(([k, v]) => `${k.replace(/_/g, ' ')} ${v.hours}h`)
+                            .join(', ');
+                          const shortSummary =
+                            deviceSummary.length > 56 ? `${deviceSummary.slice(0, 53)}…` : deviceSummary;
+                          return (
+                            <TableRow
+                              key={row.growth_day}
+                              hover
+                              selected={selectedHeaterGrowthDay === row.growth_day}
+                              onClick={() => {
+                                setSelectedHeaterGrowthDay(row.growth_day);
+                                setDodReferenceDate(row.date ?? null);
+                              }}
+                              sx={{
+                                cursor: 'pointer',
+                                '&.Mui-selected': {
+                                  bgcolor: 'action.selected',
+                                },
+                                '&:last-child td': { borderBottom: 0 },
+                              }}
+                            >
+                              <TableCell>Day {row.growth_day}</TableCell>
+                              <TableCell>{row.date ?? '—'}</TableCell>
+                              <TableCell align="right">{row.total_hours} h</TableCell>
+                              <TableCell>
+                                <Typography variant="body2" color="text.secondary" noWrap title={deviceSummary}>
+                                  {shortSummary || '—'}
+                                </Typography>
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </TableContainer>
+                  {selectedHeaterRow ? (
+                    <Box
+                      mt={2}
+                      pt={2}
+                      sx={{
+                        borderTop: 1,
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                        Selected — Day {selectedHeaterRow.growth_day}
+                        {selectedHeaterRow.date ? ` · ${selectedHeaterRow.date}` : ''} — per device
+                      </Typography>
+                      <Box display="flex" flexWrap="wrap" gap={0.5}>
+                        {Object.entries(selectedHeaterRow.per_device || {}).map(([device, value]) => (
+                          <Chip
+                            key={device}
+                            size="small"
+                            variant="outlined"
+                            label={`${device.replace(/_/g, ' ')}: ${value.hours} h`}
+                          />
+                        ))}
+                      </Box>
+                    </Box>
+                  ) : null}
+                </>
               ) : (
                 <Typography variant="body2" color="text.secondary">
                   Click &quot;Load saved&quot; or &quot;Fetch from Rotem&quot; to show heater runtime by day.
@@ -303,8 +433,12 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                   label={formatDelta(kpis?.water_day_over_day?.delta, kpis?.water_day_over_day?.delta_pct, 'L')}
                 />
               </Box>
-              <Typography variant="caption" color="text.secondary">
-                Today: {kpis?.water_day_over_day?.current?.toFixed(1) ?? 'N/A'}L | Yesterday: {kpis?.water_day_over_day?.previous?.toFixed(1) ?? 'N/A'}L
+              <Typography variant="caption" color="text.secondary" component="div">
+                {formatDodCaption(
+                  kpis?.water_day_over_day?.current,
+                  kpis?.water_day_over_day?.previous,
+                  'L'
+                )}
               </Typography>
             </CardContent>
           </Card>
@@ -324,8 +458,12 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                   label={formatDelta(kpis?.feed_day_over_day?.delta, kpis?.feed_day_over_day?.delta_pct, 'lb')}
                 />
               </Box>
-              <Typography variant="caption" color="text.secondary">
-                Today: {kpis?.feed_day_over_day?.current?.toFixed(1) ?? 'N/A'}lb | Yesterday: {kpis?.feed_day_over_day?.previous?.toFixed(1) ?? 'N/A'}lb
+              <Typography variant="caption" color="text.secondary" component="div">
+                {formatDodCaption(
+                  kpis?.feed_day_over_day?.current,
+                  kpis?.feed_day_over_day?.previous,
+                  'lb'
+                )}
               </Typography>
             </CardContent>
           </Card>

--- a/frontend/src/services/monitoringApi.ts
+++ b/frontend/src/services/monitoringApi.ts
@@ -68,11 +68,20 @@ class MonitoringApiService {
   }
 
   /**
-   * Get derived operational KPIs for house overview
+   * Get derived operational KPIs for house overview.
+   * @param options.dodReferenceDate ISO date (YYYY-MM-DD) to compare that day vs the prior day for water/feed DOD.
    */
-  async getHouseMonitoringKpis(houseId: number): Promise<HouseMonitoringKpis> {
+  async getHouseMonitoringKpis(
+    houseId: number,
+    options?: { dodReferenceDate?: string | null }
+  ): Promise<HouseMonitoringKpis> {
+    const params: Record<string, string> = {};
+    if (options?.dodReferenceDate) {
+      params.dod_reference_date = options.dodReferenceDate;
+    }
     const response = await api.get(`/houses/${houseId}/monitoring/kpis/`, {
       headers: this.getAuthHeaders(),
+      ...(Object.keys(params).length > 0 ? { params } : {}),
     });
     return response.data;
   }

--- a/frontend/src/types/monitoring.ts
+++ b/frontend/src/types/monitoring.ts
@@ -218,6 +218,11 @@ export interface MonitoringDashboardData {
 export interface HouseMonitoringKpis {
   house_id: number;
   window_hours: number;
+  /** Present when KPIs were requested with dod_reference_date (selected vs prior calendar day). */
+  day_over_day_context?: {
+    reference_date: string;
+    compare_date: string;
+  } | null;
   data_quality: {
     snapshots_24h: number;
     snapshots_7d: number;


### PR DESCRIPTION
## Summary

This PR implements heater history UX improvements and aligns water/feed day-over-day KPIs with a user-selected calendar day (from Rotem Command 43 heater history rows).

### Backend
- `GET /houses/<id>/monitoring/kpis/` accepts optional `dod_reference_date=YYYY-MM-DD`.
- When set, water/feed DOD and water/feed ratio use max-per-day snapshot values for that date vs the previous calendar day (not limited to the rolling 7-day aggregation window).
- Response includes `day_over_day_context` with `reference_date` and `compare_date` for UI labels. Invalid dates return **400**.
- Tests cover historical dates outside the 7d window and invalid input.

### Frontend
- Heater history: scrollable daily table with sticky header, row selection, and a detail panel for per-device runtime chips.
- Selecting a row (with a `date`) refetches KPIs with `dod_reference_date`; water and feed cards use dynamic labels from `day_over_day_context` (falls back to Today/Yesterday when no reference is selected).

### Notes
- Heater runtime (24h) and other KPI blocks remain anchored to the current time window, as specified.

Made with [Cursor](https://cursor.com)