### PR TITLE
feat(ui): dashboard stat navigation and house comparison layout

### DIFF
--- a/frontend/src/components/dashboard/ProfessionalDashboard.tsx
+++ b/frontend/src/components/dashboard/ProfessionalDashboard.tsx
@@ -40,39 +40,92 @@ interface StatCardProps {
     isPositive: boolean;
   };
   subtitle?: string;
+  /** When set, the main metrics (value, title, subtitle) navigate here; icon/trend stay static. */
+  navigateTo?: string;
 }
 
-const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color, trend, subtitle }) => (
-  <Card sx={{ height: '100%', position: 'relative', overflow: 'visible' }}>
-    <CardContent>
-      <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
-        <Avatar sx={{ bgcolor: `${color}.main`, width: 48, height: 48 }}>
-          {icon}
-        </Avatar>
-        {trend && (
-          <Chip
-            icon={<TrendingUpIcon />}
-            label={`${trend.isPositive ? '+' : ''}${trend.value}%`}
-            color={trend.isPositive ? 'success' : 'error'}
-            size="small"
-            variant="outlined"
-          />
-        )}
-      </Box>
-      <Typography variant="h4" fontWeight={700} color="text.primary" gutterBottom>
-        {value}
-      </Typography>
-      <Typography variant="body2" color="text.secondary" gutterBottom>
-        {title}
-      </Typography>
-      {subtitle && (
-        <Typography variant="caption" color="text.secondary">
-          {subtitle}
-        </Typography>
-      )}
-    </CardContent>
-  </Card>
-);
+const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color, trend, subtitle, navigateTo }) => {
+  const navigate = useNavigate();
+  const clickable = Boolean(navigateTo);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!clickable || !navigateTo) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      navigate(navigateTo);
+    }
+  };
+
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        position: 'relative',
+        overflow: 'visible',
+        ...(clickable && {
+          '&:focus-within': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: 2 },
+        }),
+      }}
+    >
+      <CardContent>
+        <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
+          <Avatar sx={{ bgcolor: `${color}.main`, width: 48, height: 48 }}>{icon}</Avatar>
+          {trend && (
+            <Chip
+              icon={<TrendingUpIcon />}
+              label={`${trend.isPositive ? '+' : ''}${trend.value}%`}
+              color={trend.isPositive ? 'success' : 'error'}
+              size="small"
+              variant="outlined"
+            />
+          )}
+        </Box>
+        <Box
+          role={clickable ? 'button' : undefined}
+          tabIndex={clickable ? 0 : undefined}
+          onClick={clickable && navigateTo ? () => navigate(navigateTo) : undefined}
+          onKeyDown={handleKeyDown}
+          sx={
+            clickable
+              ? {
+                  cursor: 'pointer',
+                  borderRadius: 1,
+                  mx: -0.5,
+                  px: 0.5,
+                  py: 0.25,
+                  transition: 'background-color 0.15s ease',
+                  '&:hover': {
+                    bgcolor: 'action.hover',
+                  },
+                }
+              : undefined
+          }
+        >
+          <Typography variant="h4" fontWeight={700} color="text.primary" gutterBottom>
+            {value}
+          </Typography>
+          <Typography
+            variant="body2"
+            color={clickable ? 'primary' : 'text.secondary'}
+            gutterBottom
+            sx={clickable ? { textDecoration: 'underline', textDecorationColor: 'transparent', '&:hover': { textDecorationColor: 'currentColor' } } : undefined}
+          >
+            {title}
+          </Typography>
+          {subtitle && (
+            <Typography
+              variant="caption"
+              color={clickable ? 'primary.main' : 'text.secondary'}
+              sx={clickable ? { display: 'block', opacity: 0.9 } : undefined}
+            >
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
 
 interface TaskProgressProps {
   title: string;
@@ -185,6 +238,7 @@ const ProfessionalDashboard: React.FC = () => {
             color="primary"
             subtitle={`${activeFarms} active`}
             trend={{ value: 12, isPositive: true }}
+            navigateTo="/farms"
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -195,6 +249,7 @@ const ProfessionalDashboard: React.FC = () => {
             color="secondary"
             subtitle={`${totalHouses} total`}
             trend={{ value: 8, isPositive: true }}
+            navigateTo="/farms"
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -205,6 +260,7 @@ const ProfessionalDashboard: React.FC = () => {
             color="success"
             subtitle={`${totalWorkers} total`}
             trend={{ value: 5, isPositive: true }}
+            navigateTo="/workers"
           />
         </Grid>
         <Grid item xs={12} sm={6} md={3}>
@@ -214,6 +270,7 @@ const ProfessionalDashboard: React.FC = () => {
             icon={<ProgramIcon />}
             color="warning"
             subtitle={`${totalPrograms} total`}
+            navigateTo="/programs"
           />
         </Grid>
       </Grid>

--- a/frontend/src/components/houses/ComparisonDashboard.tsx
+++ b/frontend/src/components/houses/ComparisonDashboard.tsx
@@ -360,8 +360,8 @@ const ComparisonDashboard: React.FC = () => {
 
       {/* View Tabs */}
       <Tabs value={activeTab} onChange={(_, val) => setActiveTab(val)} sx={{ mb: 2 }}>
-        <Tab icon={<Thermostat />} label="Climate" iconPosition="start" />
         <Tab icon={<Water />} label="Consumption" iconPosition="start" />
+        <Tab icon={<Thermostat />} label="Climate" iconPosition="start" />
         <Tab icon={<Air />} label="Environment" iconPosition="start" />
       </Tabs>
 
@@ -386,11 +386,56 @@ const ComparisonDashboard: React.FC = () => {
                     Day
                   </Box>
                 </TableCell>
+
+                {/* Consumption: Water & Feed before Status / Time */}
+                {activeTab === 0 && (
+                  <>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
+                      <Box display="flex" alignItems="center" gap={0.5}>
+                        <IconButton size="small" onClick={() => handleSort('water_consumption')}>
+                          <SortIcon field="water_consumption" />
+                        </IconButton>
+                        💧 Water
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
+                      <Box display="flex" alignItems="center" gap={0.5}>
+                        <IconButton size="small" onClick={() => handleSort('feed_consumption')}>
+                          <SortIcon field="feed_consumption" />
+                        </IconButton>
+                        🌾 Feed
+                      </Box>
+                    </TableCell>
+                  </>
+                )}
+
                 <TableCell sx={{ ...headerCellStyle, minWidth: 70 }}>Status</TableCell>
                 <TableCell sx={{ ...headerCellStyle, minWidth: 60 }}>Time</TableCell>
 
-                {/* Climate Tab */}
+                {/* Consumption: Birds & Livability after Status / Time */}
                 {activeTab === 0 && (
+                  <>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
+                      <Box display="flex" alignItems="center" gap={0.5}>
+                        <IconButton size="small" onClick={() => handleSort('bird_count')}>
+                          <SortIcon field="bird_count" />
+                        </IconButton>
+                        🐔 Birds
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>
+                      <Box display="flex" alignItems="center" gap={0.5}>
+                        <IconButton size="small" onClick={() => handleSort('livability')}>
+                          <SortIcon field="livability" />
+                        </IconButton>
+                        Livability
+                      </Box>
+                    </TableCell>
+                  </>
+                )}
+
+                {/* Climate Tab (index 1) */}
+                {activeTab === 1 && (
                   <>
                     <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>
                       <Box display="flex" alignItems="center" gap={0.5}>
@@ -416,44 +461,6 @@ const ComparisonDashboard: React.FC = () => {
                           <SortIcon field="static_pressure" />
                         </IconButton>
                         Pressure
-                      </Box>
-                    </TableCell>
-                  </>
-                )}
-
-                {/* Consumption Tab */}
-                {activeTab === 1 && (
-                  <>
-                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <IconButton size="small" onClick={() => handleSort('water_consumption')}>
-                          <SortIcon field="water_consumption" />
-                        </IconButton>
-                        💧 Water
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <IconButton size="small" onClick={() => handleSort('feed_consumption')}>
-                          <SortIcon field="feed_consumption" />
-                        </IconButton>
-                        🌾 Feed
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ ...headerCellStyle, minWidth: 100 }}>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <IconButton size="small" onClick={() => handleSort('bird_count')}>
-                          <SortIcon field="bird_count" />
-                        </IconButton>
-                        🐔 Birds
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>
-                      <Box display="flex" alignItems="center" gap={0.5}>
-                        <IconButton size="small" onClick={() => handleSort('livability')}>
-                          <SortIcon field="livability" />
-                        </IconButton>
-                        Livability
                       </Box>
                     </TableCell>
                   </>
@@ -517,6 +524,23 @@ const ComparisonDashboard: React.FC = () => {
                         variant={house.is_full_house ? 'filled' : 'outlined'}
                       />
                     </TableCell>
+
+                    {/* Consumption: Water & Feed before Status / Time */}
+                    {activeTab === 0 && (
+                      <>
+                        <TableCell sx={cellStyle}>
+                          <Typography variant="body2" fontWeight="medium" color="info.main">
+                            {formatConsumption(house.water_consumption, 'L')}
+                          </Typography>
+                        </TableCell>
+                        <TableCell sx={cellStyle}>
+                          <Typography variant="body2" fontWeight="medium" color="warning.main">
+                            {formatConsumption(house.feed_consumption, 'lb')}
+                          </Typography>
+                        </TableCell>
+                      </>
+                    )}
+
                     <TableCell sx={cellStyle}>
                       <Chip 
                         label={house.status}
@@ -531,8 +555,26 @@ const ComparisonDashboard: React.FC = () => {
                       </Typography>
                     </TableCell>
 
-                    {/* Climate Tab */}
+                    {/* Consumption: Birds & Livability after Status / Time */}
                     {activeTab === 0 && (
+                      <>
+                        <TableCell sx={cellStyle}>
+                          <Typography variant="body2">
+                            {formatNumber(house.bird_count)}
+                          </Typography>
+                        </TableCell>
+                        <TableCell sx={cellStyle}>
+                          <Typography variant="body2" color={
+                            house.livability && house.livability < 95 ? 'error.main' : 'success.main'
+                          }>
+                            {formatPercent(house.livability)}
+                          </Typography>
+                        </TableCell>
+                      </>
+                    )}
+
+                    {/* Climate Tab (index 1) */}
+                    {activeTab === 1 && (
                       <>
                         <TableCell sx={cellStyle}>
                           <Typography variant="body2" fontWeight="medium" color={
@@ -549,34 +591,6 @@ const ComparisonDashboard: React.FC = () => {
                         <TableCell sx={cellStyle}>{formatTemp(house.outside_temperature)}</TableCell>
                         <TableCell sx={cellStyle}>{formatHumidity(house.inside_humidity)}</TableCell>
                         <TableCell sx={cellStyle}>{formatPressure(house.static_pressure)}</TableCell>
-                      </>
-                    )}
-
-                    {/* Consumption Tab */}
-                    {activeTab === 1 && (
-                      <>
-                        <TableCell sx={cellStyle}>
-                          <Typography variant="body2" fontWeight="medium" color="info.main">
-                            {formatConsumption(house.water_consumption, 'L')}
-                          </Typography>
-                        </TableCell>
-                        <TableCell sx={cellStyle}>
-                          <Typography variant="body2" fontWeight="medium" color="warning.main">
-                            {formatConsumption(house.feed_consumption, 'lb')}
-                          </Typography>
-                        </TableCell>
-                        <TableCell sx={cellStyle}>
-                          <Typography variant="body2">
-                            {formatNumber(house.bird_count)}
-                          </Typography>
-                        </TableCell>
-                        <TableCell sx={cellStyle}>
-                          <Typography variant="body2" color={
-                            house.livability && house.livability < 95 ? 'error.main' : 'success.main'
-                          }>
-                            {formatPercent(house.livability)}
-                          </Typography>
-                        </TableCell>
                       </>
                     )}
 


### PR DESCRIPTION
## Summary

### Dashboard (`ProfessionalDashboard`)
- Stat cards expose **clickable** (and keyboard-focusable) **value / title / subtitle** regions that navigate to:
  - **Total Farms** and **Active Houses** → `/farms`
  - **Workers** → `/workers`
  - **Task Programs** → `/programs`
- Avatar and trend chip are not part of the navigation target.

### House comparison (`ComparisonDashboard`)
- **Consumption** tab is first in the tab list.
- On the Consumption tab, **Water** and **Feed** columns appear **before** Status and Time (Birds and Livability remain after Status/Time).

Made with [Cursor](https://cursor.com)