### PR TITLE
feat(ios): native SwiftUI app — monitoring, comparison, house KPIs

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,10 @@
+# Xcode / Swift
+DerivedData/
+.derivedData/
+build/
+*.xcuserstate
+xcuserdata/
+
+# SwiftPM
+.swiftpm/xcode/package.xcworkspace/xcuserdata/
+.build/

--- a/ios/FarmManagementApp.xcodeproj/project.pbxproj
+++ b/ios/FarmManagementApp.xcodeproj/project.pbxproj
@@ -1,0 +1,574 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		0F87C02B3BE46B9AE976EA3D /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83311988CE432E2DC725C69D /* RootView.swift */; };
+		1E1CA70BC66B53AE31307DE8 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F4ECEDC69D86486656F65B /* LoginView.swift */; };
+		3677582FAAD2A4181842B0BA /* FarmComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC41BCCC15B9A48D15B0E5D5 /* FarmComparisonView.swift */; };
+		3E02E18A29F17D6F1CDEC7D7 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693F8E3340CDECE42C6D5494 /* DashboardViewModel.swift */; };
+		4F899843528333B34E551A22 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2780432A6C93373EBCA4A049 /* Foundation.framework */; };
+		56C64421B43F9B32BB8EC397 /* FarmComparisonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3B11D285FA74183F60D900 /* FarmComparisonViewModel.swift */; };
+		69B73AA16319E865DEC6F2EA /* HouseDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD4E8868E78AD1B450A27B0 /* HouseDetailViewModel.swift */; };
+		70641CFF702273F69617BEAD /* FarmManagementCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC1268EA696F767FD6B95C66 /* FarmManagementCore.framework */; };
+		748B3A3C0AD848FA3F1C4796 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2D1DB92B3AF3BF1D1BA0EF /* AppState.swift */; };
+		7762FCE6A4A6644FAF7A12A1 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13188FAF699BA530F7D96CB /* Models.swift */; };
+		9164D75ACD1BC488D0A12C0D /* FarmMonitoringViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4539DA518B95D8B8F7F1CA /* FarmMonitoringViewModel.swift */; };
+		939A2825628EC4F686E46115 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30A29F9D197A82B91913ED3 /* DashboardView.swift */; };
+		9B316BEC18986F879477D629 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B117F58CB3A87B516515F5 /* Networking.swift */; };
+		AD5C6054FFCFB3663759BE2B /* AppContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3977BC808012B015931D65D8 /* AppContainer.swift */; };
+		B00EDB957D753F4283914A7F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2780432A6C93373EBCA4A049 /* Foundation.framework */; };
+		B220EB1F2AEF84E5DBE61F1C /* ErrorStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B66955891807C58372F101 /* ErrorStateView.swift */; };
+		BD346A586C8ADA2265BFDF89 /* HouseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E9D2844FA1B882E528168C /* HouseDetailView.swift */; };
+		CA70E09DEFB6FE36DF9DE6D7 /* LoadableState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A003E4021B5C4C4AA36FDA9 /* LoadableState.swift */; };
+		CF928411EBBFD6D4A1DA412E /* FarmDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B453590506419B01AE2DB3 /* FarmDetailViewModel.swift */; };
+		CFEC372F237621411BA09184 /* FarmDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE1620F0BC7F2D638EA17FC /* FarmDetailView.swift */; };
+		D28C3CC1A40B58AE47A1E6BA /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8CE0704F33C155122AE079 /* AppEnvironment.swift */; };
+		EA0564FCE8B0E48229D2A477 /* FarmManagementCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC1268EA696F767FD6B95C66 /* FarmManagementCore.framework */; };
+		EB811898D3E7CA5F287210A8 /* FarmListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032758326157ED25459217C3 /* FarmListView.swift */; };
+		F25363E193CCE126CF4889A0 /* FarmManagementIOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C404B45A570E909700ABCF /* FarmManagementIOSApp.swift */; };
+		F6B10EA87301D3F15A6FF865 /* FarmListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6BB7DA16FD3BA386B57707D /* FarmListViewModel.swift */; };
+		FC226A1559B600C77FD5B160 /* Services.swift in Sources */ = {isa = PBXBuildFile; fileRef = 432266B1668613EAB92590E4 /* Services.swift */; };
+		FC6A8B820B699F1840B756D4 /* FarmMonitoringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4356C51F31216D39070C9A79 /* FarmMonitoringView.swift */; };
+		FF250A3F49F5E778F630C182 /* KeychainTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47A08E4AF31620963A6BD5BE /* KeychainTokenStore.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4879D481FD49FB5A58B0B029 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 139667D06198D0362E791A5A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3F448A0F6B48CAD5EEDB89F7;
+			remoteInfo = FarmManagementCore;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		99819337F11D9EBB699283C9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				EA0564FCE8B0E48229D2A477 /* FarmManagementCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		032758326157ED25459217C3 /* FarmListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmListView.swift; path = FarmManagementApp/Features/Farms/FarmListView.swift; sourceTree = "<group>"; };
+		0A6B7059EDE196719DD07E18 /* FarmManagementApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FarmManagementApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		11C404B45A570E909700ABCF /* FarmManagementIOSApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmManagementIOSApp.swift; path = FarmManagementApp/FarmManagementIOSApp.swift; sourceTree = "<group>"; };
+		24F4ECEDC69D86486656F65B /* LoginView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginView.swift; path = FarmManagementApp/Features/Auth/LoginView.swift; sourceTree = "<group>"; };
+		2780432A6C93373EBCA4A049 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		3977BC808012B015931D65D8 /* AppContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppContainer.swift; path = FarmManagementApp/Core/AppContainer.swift; sourceTree = "<group>"; };
+		432266B1668613EAB92590E4 /* Services.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Services.swift; path = FarmManagementCore/Sources/FarmManagementCore/Services.swift; sourceTree = "<group>"; };
+		4356C51F31216D39070C9A79 /* FarmMonitoringView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmMonitoringView.swift; path = FarmManagementApp/Features/Monitoring/FarmMonitoringView.swift; sourceTree = "<group>"; };
+		47A08E4AF31620963A6BD5BE /* KeychainTokenStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KeychainTokenStore.swift; path = FarmManagementApp/Core/KeychainTokenStore.swift; sourceTree = "<group>"; };
+		65B66955891807C58372F101 /* ErrorStateView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorStateView.swift; path = FarmManagementApp/SharedUI/ErrorStateView.swift; sourceTree = "<group>"; };
+		693F8E3340CDECE42C6D5494 /* DashboardViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardViewModel.swift; path = FarmManagementApp/Features/Dashboard/DashboardViewModel.swift; sourceTree = "<group>"; };
+		7B3B11D285FA74183F60D900 /* FarmComparisonViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmComparisonViewModel.swift; path = FarmManagementApp/Features/Comparison/FarmComparisonViewModel.swift; sourceTree = "<group>"; };
+		83311988CE432E2DC725C69D /* RootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RootView.swift; path = FarmManagementApp/Features/RootView.swift; sourceTree = "<group>"; };
+		8F8CE0704F33C155122AE079 /* AppEnvironment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppEnvironment.swift; path = FarmManagementApp/Core/AppEnvironment.swift; sourceTree = "<group>"; };
+		9A003E4021B5C4C4AA36FDA9 /* LoadableState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadableState.swift; path = FarmManagementApp/Core/LoadableState.swift; sourceTree = "<group>"; };
+		A13188FAF699BA530F7D96CB /* Models.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Models.swift; path = FarmManagementCore/Sources/FarmManagementCore/Models.swift; sourceTree = "<group>"; };
+		A8B453590506419B01AE2DB3 /* FarmDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmDetailViewModel.swift; path = FarmManagementApp/Features/Farms/FarmDetailViewModel.swift; sourceTree = "<group>"; };
+		AC1268EA696F767FD6B95C66 /* FarmManagementCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FarmManagementCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC4539DA518B95D8B8F7F1CA /* FarmMonitoringViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmMonitoringViewModel.swift; path = FarmManagementApp/Features/Monitoring/FarmMonitoringViewModel.swift; sourceTree = "<group>"; };
+		BBD4E8868E78AD1B450A27B0 /* HouseDetailViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HouseDetailViewModel.swift; path = FarmManagementApp/Features/Houses/HouseDetailViewModel.swift; sourceTree = "<group>"; };
+		BD2D1DB92B3AF3BF1D1BA0EF /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppState.swift; path = FarmManagementApp/Core/AppState.swift; sourceTree = "<group>"; };
+		C5E9D2844FA1B882E528168C /* HouseDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HouseDetailView.swift; path = FarmManagementApp/Features/Houses/HouseDetailView.swift; sourceTree = "<group>"; };
+		D4B334C1F5E20D54FB80E68B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = FarmManagementApp/Config/Info.plist; sourceTree = "<group>"; };
+		D5B117F58CB3A87B516515F5 /* Networking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Networking.swift; path = FarmManagementCore/Sources/FarmManagementCore/Networking.swift; sourceTree = "<group>"; };
+		DCE1620F0BC7F2D638EA17FC /* FarmDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmDetailView.swift; path = FarmManagementApp/Features/Farms/FarmDetailView.swift; sourceTree = "<group>"; };
+		EC41BCCC15B9A48D15B0E5D5 /* FarmComparisonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmComparisonView.swift; path = FarmManagementApp/Features/Comparison/FarmComparisonView.swift; sourceTree = "<group>"; };
+		F30A29F9D197A82B91913ED3 /* DashboardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardView.swift; path = FarmManagementApp/Features/Dashboard/DashboardView.swift; sourceTree = "<group>"; };
+		F6BB7DA16FD3BA386B57707D /* FarmListViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FarmListViewModel.swift; path = FarmManagementApp/Features/Farms/FarmListViewModel.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A411B88633ECB601AC856F72 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4F899843528333B34E551A22 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BAD30485E731D91144D97052 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B00EDB957D753F4283914A7F /* Foundation.framework in Frameworks */,
+				70641CFF702273F69617BEAD /* FarmManagementCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3CBA4FA5D315BF976B49C401 /* FarmManagementCore */ = {
+			isa = PBXGroup;
+			children = (
+				A13188FAF699BA530F7D96CB /* Models.swift */,
+				D5B117F58CB3A87B516515F5 /* Networking.swift */,
+				432266B1668613EAB92590E4 /* Services.swift */,
+			);
+			name = FarmManagementCore;
+			sourceTree = "<group>";
+		};
+		6F2CA2FD5EA00F28F0633373 /* FarmManagementApp */ = {
+			isa = PBXGroup;
+			children = (
+				3977BC808012B015931D65D8 /* AppContainer.swift */,
+				8F8CE0704F33C155122AE079 /* AppEnvironment.swift */,
+				BD2D1DB92B3AF3BF1D1BA0EF /* AppState.swift */,
+				47A08E4AF31620963A6BD5BE /* KeychainTokenStore.swift */,
+				9A003E4021B5C4C4AA36FDA9 /* LoadableState.swift */,
+				11C404B45A570E909700ABCF /* FarmManagementIOSApp.swift */,
+				24F4ECEDC69D86486656F65B /* LoginView.swift */,
+				EC41BCCC15B9A48D15B0E5D5 /* FarmComparisonView.swift */,
+				7B3B11D285FA74183F60D900 /* FarmComparisonViewModel.swift */,
+				F30A29F9D197A82B91913ED3 /* DashboardView.swift */,
+				693F8E3340CDECE42C6D5494 /* DashboardViewModel.swift */,
+				DCE1620F0BC7F2D638EA17FC /* FarmDetailView.swift */,
+				A8B453590506419B01AE2DB3 /* FarmDetailViewModel.swift */,
+				032758326157ED25459217C3 /* FarmListView.swift */,
+				F6BB7DA16FD3BA386B57707D /* FarmListViewModel.swift */,
+				C5E9D2844FA1B882E528168C /* HouseDetailView.swift */,
+				BBD4E8868E78AD1B450A27B0 /* HouseDetailViewModel.swift */,
+				4356C51F31216D39070C9A79 /* FarmMonitoringView.swift */,
+				AC4539DA518B95D8B8F7F1CA /* FarmMonitoringViewModel.swift */,
+				83311988CE432E2DC725C69D /* RootView.swift */,
+				65B66955891807C58372F101 /* ErrorStateView.swift */,
+				D4B334C1F5E20D54FB80E68B /* Info.plist */,
+			);
+			name = FarmManagementApp;
+			sourceTree = "<group>";
+		};
+		84027AA267AD744208D22B37 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				0A6B7059EDE196719DD07E18 /* FarmManagementApp.app */,
+				AC1268EA696F767FD6B95C66 /* FarmManagementCore.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8D43EBD743CFF4584D484653 = {
+			isa = PBXGroup;
+			children = (
+				84027AA267AD744208D22B37 /* Products */,
+				C76EFF2F52FF52176C319F88 /* Frameworks */,
+				6F2CA2FD5EA00F28F0633373 /* FarmManagementApp */,
+				3CBA4FA5D315BF976B49C401 /* FarmManagementCore */,
+			);
+			sourceTree = "<group>";
+		};
+		C76EFF2F52FF52176C319F88 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CCF96BF99BC24B9EFD9B716B /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CCF96BF99BC24B9EFD9B716B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2780432A6C93373EBCA4A049 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		0BF8D32AAACF984842E83B69 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		3F448A0F6B48CAD5EEDB89F7 /* FarmManagementCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FA6802C35F93A56409512663 /* Build configuration list for PBXNativeTarget "FarmManagementCore" */;
+			buildPhases = (
+				0BF8D32AAACF984842E83B69 /* Headers */,
+				FB932E4A69D30DDE566D9C93 /* Sources */,
+				A411B88633ECB601AC856F72 /* Frameworks */,
+				44B8440908FBEB33137952EB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FarmManagementCore;
+			productName = FarmManagementCore;
+			productReference = AC1268EA696F767FD6B95C66 /* FarmManagementCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B54EE8B605659F0156E1EC3A /* FarmManagementApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6C883297B827BC0AFF762540 /* Build configuration list for PBXNativeTarget "FarmManagementApp" */;
+			buildPhases = (
+				0443C3C942E44E4E50B987DA /* Sources */,
+				BAD30485E731D91144D97052 /* Frameworks */,
+				632FED48D441DA529D914C57 /* Resources */,
+				99819337F11D9EBB699283C9 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				08707D2D839CAD4D64A7E857 /* PBXTargetDependency */,
+			);
+			name = FarmManagementApp;
+			productName = FarmManagementApp;
+			productReference = 0A6B7059EDE196719DD07E18 /* FarmManagementApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		139667D06198D0362E791A5A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = 58CF4F8BDB026CFB0FCE0B3C /* Build configuration list for PBXProject "FarmManagementApp" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 8D43EBD743CFF4584D484653;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 84027AA267AD744208D22B37 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				B54EE8B605659F0156E1EC3A /* FarmManagementApp */,
+				3F448A0F6B48CAD5EEDB89F7 /* FarmManagementCore */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		44B8440908FBEB33137952EB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		632FED48D441DA529D914C57 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0443C3C942E44E4E50B987DA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AD5C6054FFCFB3663759BE2B /* AppContainer.swift in Sources */,
+				D28C3CC1A40B58AE47A1E6BA /* AppEnvironment.swift in Sources */,
+				748B3A3C0AD848FA3F1C4796 /* AppState.swift in Sources */,
+				FF250A3F49F5E778F630C182 /* KeychainTokenStore.swift in Sources */,
+				CA70E09DEFB6FE36DF9DE6D7 /* LoadableState.swift in Sources */,
+				F25363E193CCE126CF4889A0 /* FarmManagementIOSApp.swift in Sources */,
+				1E1CA70BC66B53AE31307DE8 /* LoginView.swift in Sources */,
+				3677582FAAD2A4181842B0BA /* FarmComparisonView.swift in Sources */,
+				56C64421B43F9B32BB8EC397 /* FarmComparisonViewModel.swift in Sources */,
+				939A2825628EC4F686E46115 /* DashboardView.swift in Sources */,
+				3E02E18A29F17D6F1CDEC7D7 /* DashboardViewModel.swift in Sources */,
+				CFEC372F237621411BA09184 /* FarmDetailView.swift in Sources */,
+				CF928411EBBFD6D4A1DA412E /* FarmDetailViewModel.swift in Sources */,
+				EB811898D3E7CA5F287210A8 /* FarmListView.swift in Sources */,
+				F6B10EA87301D3F15A6FF865 /* FarmListViewModel.swift in Sources */,
+				BD346A586C8ADA2265BFDF89 /* HouseDetailView.swift in Sources */,
+				69B73AA16319E865DEC6F2EA /* HouseDetailViewModel.swift in Sources */,
+				FC6A8B820B699F1840B756D4 /* FarmMonitoringView.swift in Sources */,
+				9164D75ACD1BC488D0A12C0D /* FarmMonitoringViewModel.swift in Sources */,
+				0F87C02B3BE46B9AE976EA3D /* RootView.swift in Sources */,
+				B220EB1F2AEF84E5DBE61F1C /* ErrorStateView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB932E4A69D30DDE566D9C93 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7762FCE6A4A6644FAF7A12A1 /* Models.swift in Sources */,
+				9B316BEC18986F879477D629 /* Networking.swift in Sources */,
+				FC226A1559B600C77FD5B160 /* Services.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		08707D2D839CAD4D64A7E857 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = FarmManagementCore;
+			target = 3F448A0F6B48CAD5EEDB89F7 /* FarmManagementCore */;
+			targetProxy = 4879D481FD49FB5A58B0B029 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		06F9533117987EEDE70A4D53 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		5CF46768CF7394C8FE966E97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		8480D23196F6A0F37573F51D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = FarmManagementApp/Config/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.farmmanagement.ios;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		B988B91E16DD352C3F71F758 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.farmmanagement.core;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		BF27B8F7F5511D3996BFADFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = FarmManagementApp/Config/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.farmmanagement.ios;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		C42ED40217B60D09B4CF53A6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_dylib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.farmmanagement.core;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58CF4F8BDB026CFB0FCE0B3C /* Build configuration list for PBXProject "FarmManagementApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				06F9533117987EEDE70A4D53 /* Debug */,
+				5CF46768CF7394C8FE966E97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6C883297B827BC0AFF762540 /* Build configuration list for PBXNativeTarget "FarmManagementApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8480D23196F6A0F37573F51D /* Release */,
+				BF27B8F7F5511D3996BFADFE /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FA6802C35F93A56409512663 /* Build configuration list for PBXNativeTarget "FarmManagementCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B988B91E16DD352C3F71F758 /* Release */,
+				C42ED40217B60D09B4CF53A6 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 139667D06198D0362E791A5A /* Project object */;
+}

--- a/ios/FarmManagementApp/Config/Info.plist
+++ b/ios/FarmManagementApp/Config/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+			<key>127.0.0.1</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>API_BASE_URL_DEBUG</key>
+	<string>https://farm-management-production-54e4.up.railway.app/api/</string>
+	<key>API_BASE_URL_RELEASE</key>
+	<string>https://farm-management-production-54e4.up.railway.app/api/</string>
+</dict>
+</plist>

--- a/ios/FarmManagementApp/Core/AppContainer.swift
+++ b/ios/FarmManagementApp/Core/AppContainer.swift
@@ -1,0 +1,14 @@
+import Foundation
+import FarmManagementCore
+
+final class AppContainer {
+    static let shared = AppContainer()
+
+    let tokenStore = KeychainTokenStore()
+    lazy var apiClient = APIClient(baseURL: AppEnvironment.apiBaseURL, tokenProvider: tokenStore)
+    lazy var authService = AuthService(client: apiClient)
+    lazy var farmService = FarmService(client: apiClient)
+    lazy var houseService = HouseService(client: apiClient)
+
+    private init() {}
+}

--- a/ios/FarmManagementApp/Core/AppEnvironment.swift
+++ b/ios/FarmManagementApp/Core/AppEnvironment.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum AppEnvironment {
+    static var apiBaseURL: URL {
+        #if DEBUG
+        let key = "API_BASE_URL_DEBUG"
+        #else
+        let key = "API_BASE_URL_RELEASE"
+        #endif
+
+        if let configured = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+           let url = URL(string: configured), configured.isEmpty == false {
+            return url
+        }
+        return URL(string: "https://farm-management-production-54e4.up.railway.app/api/")!
+    }
+
+    static let deploymentTarget = "iOS 16.0+"
+    static let devicePolicy = "iPhone-first"
+}

--- a/ios/FarmManagementApp/Core/AppState.swift
+++ b/ios/FarmManagementApp/Core/AppState.swift
@@ -1,0 +1,50 @@
+import Foundation
+import FarmManagementCore
+
+@MainActor
+final class AppState: ObservableObject {
+    @Published var user: AuthUser?
+    @Published var authError: String?
+
+    private let container = AppContainer.shared
+
+    var tokenStore: KeychainTokenStore { container.tokenStore }
+    var authService: AuthService { container.authService }
+    var farmService: FarmService { container.farmService }
+    var houseService: HouseService { container.houseService }
+
+    var isAuthenticated: Bool {
+        user != nil && (tokenStore.readToken()?.isEmpty == false)
+    }
+
+    func restoreSession() async {
+        guard tokenStore.readToken() != nil else { return }
+        do {
+            user = try await authService.currentUser()
+            authError = nil
+        } catch {
+            tokenStore.clear()
+            user = nil
+            authError = nil
+        }
+    }
+
+    func login(username: String, password: String) async -> Bool {
+        do {
+            let response = try await authService.login(username: username, password: password)
+            tokenStore.save(token: response.token)
+            user = response.user
+            authError = nil
+            return true
+        } catch {
+            authError = (error as? LocalizedError)?.errorDescription ?? "Login failed."
+            return false
+        }
+    }
+
+    func logout() {
+        tokenStore.clear()
+        user = nil
+        authError = nil
+    }
+}

--- a/ios/FarmManagementApp/Core/KeychainTokenStore.swift
+++ b/ios/FarmManagementApp/Core/KeychainTokenStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Security
+import FarmManagementCore
+
+final class KeychainTokenStore: TokenProvider {
+    private let service = "com.farmmanagement.ios"
+    private let account = "auth_token"
+
+    func save(token: String) {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecItemNotFound {
+            var createQuery = query
+            createQuery[kSecValueData as String] = data
+            SecItemAdd(createQuery as CFDictionary, nil)
+        }
+    }
+
+    func readToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return token
+    }
+
+    func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/FarmManagementApp/Core/LoadableState.swift
+++ b/ios/FarmManagementApp/Core/LoadableState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum LoadableState<Value> {
+    case idle
+    case loading
+    case loaded(Value)
+    case failed(String)
+}

--- a/ios/FarmManagementApp/FarmManagementIOSApp.swift
+++ b/ios/FarmManagementApp/FarmManagementIOSApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import FarmManagementCore
+
+@main
+struct FarmManagementIOSApp: App {
+    @StateObject private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(appState)
+                .task {
+                    await appState.restoreSession()
+                }
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Auth/LoginView.swift
+++ b/ios/FarmManagementApp/Features/Auth/LoginView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var username = ""
+    @State private var password = ""
+    @State private var isSubmitting = false
+    @FocusState private var focusedField: Field?
+
+    private enum Field {
+        case username
+        case password
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                LinearGradient(
+                    colors: [Color.green.opacity(0.18), Color.blue.opacity(0.12), Color.clear],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: 20) {
+                        VStack(spacing: 8) {
+                            Image(systemName: "leaf.circle.fill")
+                                .font(.system(size: 54))
+                                .foregroundStyle(.green)
+                            Text("Farm Management")
+                                .font(.largeTitle.weight(.bold))
+                            Text("Sign in to monitor your farms in real time.")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.top, 28)
+
+                        VStack(spacing: 14) {
+                            TextField("Username", text: $username)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .keyboardType(.asciiCapable)
+                                .textContentType(.username)
+                                .submitLabel(.next)
+                                .focused($focusedField, equals: .username)
+                                .onSubmit { focusedField = .password }
+                                .padding(12)
+                                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+
+                            SecureField("Password", text: $password)
+                                .textContentType(.password)
+                                .submitLabel(.go)
+                                .focused($focusedField, equals: .password)
+                                .onSubmit { submit() }
+                                .padding(12)
+                                .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12))
+
+                            if let error = appState.authError {
+                                Text(error)
+                                    .foregroundStyle(.red)
+                                    .font(.footnote)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+
+                            Button(action: submit) {
+                                Group {
+                                    if isSubmitting {
+                                        ProgressView()
+                                    } else {
+                                        Text("Sign In")
+                                            .fontWeight(.semibold)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.green)
+                            .disabled(username.isEmpty || password.isEmpty || isSubmitting)
+                        }
+                        .padding(16)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18))
+                    }
+                    .padding(.horizontal)
+                }
+            }
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") { focusedField = nil }
+                }
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .navigationTitle("Login")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func submit() {
+        guard username.isEmpty == false, password.isEmpty == false, isSubmitting == false else {
+            return
+        }
+        focusedField = nil
+        Task {
+            isSubmitting = true
+            _ = await appState.login(username: username, password: password)
+            isSubmitting = false
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Comparison/FarmComparisonView.swift
+++ b/ios/FarmManagementApp/Features/Comparison/FarmComparisonView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import FarmManagementCore
+
+struct FarmComparisonView: View {
+    @StateObject private var viewModel: FarmComparisonViewModel
+    @State private var selectedTab = 0
+
+    init(farmID: Int) {
+        _viewModel = StateObject(
+            wrappedValue: FarmComparisonViewModel(
+                farmID: farmID,
+                service: AppContainer.shared.farmService
+            )
+        )
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView("Loading comparison...")
+            case .failed(let message):
+                ErrorStateView(
+                    title: "Unable to load comparison",
+                    systemImage: "exclamationmark.triangle",
+                    message: message
+                )
+            case .loaded(let houses):
+                List {
+                    Section("Controls") {
+                        Picker("Metrics", selection: $selectedTab) {
+                            Text("Climate").tag(0)
+                            Text("Consumption").tag(1)
+                            Text("Environment").tag(2)
+                        }
+                        .pickerStyle(.segmented)
+
+                        Menu {
+                            ForEach(ComparisonSortField.allCases, id: \.self) { field in
+                                Button(field.rawValue) {
+                                    viewModel.toggleSort(field)
+                                }
+                            }
+                        } label: {
+                            Label("Sort: \(viewModel.sortField.rawValue)", systemImage: "arrow.up.arrow.down")
+                        }
+                    }
+
+                    Section("Houses") {
+                        ForEach(houses) { house in
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Text("House \(house.houseNumber)")
+                                        .font(.headline)
+                                    Spacer()
+                                    Text(house.alarmStatus)
+                                        .font(.caption2.bold())
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .background((house.alarmStatus == "critical" ? Color.red.opacity(0.15) : Color.green.opacity(0.15)), in: Capsule())
+                                        .foregroundStyle(house.alarmStatus == "critical" ? .red : .green)
+                                }
+                                HStack(spacing: 12) {
+                                    Label("Freshness: \(freshnessText(house.lastUpdateTime))", systemImage: "clock")
+                                    Label(house.hasAlarms ? "Has alarms" : "No alarms", systemImage: house.hasAlarms ? "bell.badge.fill" : "bell")
+                                }
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                metricRow(for: house)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+                .refreshable { await viewModel.load() }
+            }
+        }
+        .navigationTitle("House Comparison")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if case .idle = viewModel.state {
+                await viewModel.load()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func metricRow(for house: HouseComparisonItem) -> some View {
+        switch selectedTab {
+        case 0:
+            HStack(spacing: 12) {
+                Text("Temp: \(num(house.averageTemperature, suffix: "F"))")
+                Text("Humidity: \(num(house.insideHumidity, suffix: "%"))")
+                Text("Pressure: \(num(house.staticPressure))")
+                Text("ΔTarget: \(deltaToTarget(house))")
+                Text("Spread: \(insideOutsideSpread(house))")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        case 1:
+            HStack {
+                Text("Water: \(num(house.waterConsumption, suffix: "L"))")
+                Text("Feed: \(num(house.feedConsumption, suffix: "lb"))")
+                Text("W/Bird: \(num(house.waterPerBird, suffix: "L"))")
+                Text("F/Bird: \(num(house.feedPerBird, suffix: "lb"))")
+                Text("W:F \(num(house.waterFeedRatio))")
+                Text("Birds: \(house.birdCount.map(String.init) ?? "---")")
+                Text("Livability: \(num(house.livability, suffix: "%"))")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        default:
+            HStack {
+                Text("Day: \(house.ageDays.map(String.init) ?? "---")")
+                Text("Connected: \(house.isConnected ? "Yes" : "No")")
+                Text("Airflow%: \(num(house.airflowPercentage, suffix: "%"))")
+                Text("Heater: \(house.heaterOn == true ? "On" : "Off")")
+                Text("Fans: \(house.fanOn == true ? "On" : "Off")")
+                Text("Wind: \(num(house.windSpeed))")
+                Text("Status: \(house.status)")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private func num(_ value: Double?, suffix: String = "") -> String {
+        guard let value else { return "---" }
+        return String(format: "%.1f%@", value, suffix)
+    }
+
+    private func deltaToTarget(_ house: HouseComparisonItem) -> String {
+        guard let avg = house.averageTemperature, let target = house.targetTemperature else { return "---" }
+        let delta = avg - target
+        return String(format: "%+.1fF", delta)
+    }
+
+    private func insideOutsideSpread(_ house: HouseComparisonItem) -> String {
+        guard let inside = house.averageTemperature, let outside = house.outsideTemperature else { return "---" }
+        let spread = inside - outside
+        return String(format: "%+.1fF", spread)
+    }
+
+    private func freshnessText(_ timestamp: String?) -> String {
+        guard let timestamp,
+              let parsed = ISO8601DateFormatter().date(from: timestamp) else {
+            return "Unknown"
+        }
+        let minutes = Int(Date().timeIntervalSince(parsed) / 60)
+        if minutes < 2 { return "Live" }
+        if minutes < 15 { return "\(minutes)m" }
+        return "\(minutes)m stale"
+    }
+}

--- a/ios/FarmManagementApp/Features/Comparison/FarmComparisonViewModel.swift
+++ b/ios/FarmManagementApp/Features/Comparison/FarmComparisonViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import FarmManagementCore
+
+enum ComparisonSortField: String, CaseIterable {
+    case houseNumber
+    case ageDays
+    case averageTemperature
+    case waterConsumption
+    case feedConsumption
+    case birdCount
+    case livability
+}
+
+@MainActor
+final class FarmComparisonViewModel: ObservableObject {
+    @Published var state: LoadableState<[HouseComparisonItem]> = .idle
+    @Published var sortField: ComparisonSortField = .houseNumber
+    @Published var ascending = true
+
+    private let farmID: Int
+    private let service: FarmService
+
+    init(farmID: Int, service: FarmService) {
+        self.farmID = farmID
+        self.service = service
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let response = try await service.fetchFarmComparison(farmID: farmID)
+            state = .loaded(sorted(response.houses))
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load comparison.")
+        }
+    }
+
+    func toggleSort(_ field: ComparisonSortField) {
+        if sortField == field {
+            ascending.toggle()
+        } else {
+            sortField = field
+            ascending = true
+        }
+        if case .loaded(let houses) = state {
+            state = .loaded(sorted(houses))
+        }
+    }
+
+    private func sorted(_ houses: [HouseComparisonItem]) -> [HouseComparisonItem] {
+        houses.sorted { lhs, rhs in
+            let result: Bool
+            switch sortField {
+            case .houseNumber:
+                result = lhs.houseNumber < rhs.houseNumber
+            case .ageDays:
+                result = (lhs.ageDays ?? -1) < (rhs.ageDays ?? -1)
+            case .averageTemperature:
+                result = (lhs.averageTemperature ?? -1) < (rhs.averageTemperature ?? -1)
+            case .waterConsumption:
+                result = (lhs.waterConsumption ?? -1) < (rhs.waterConsumption ?? -1)
+            case .feedConsumption:
+                result = (lhs.feedConsumption ?? -1) < (rhs.feedConsumption ?? -1)
+            case .birdCount:
+                result = (lhs.birdCount ?? -1) < (rhs.birdCount ?? -1)
+            case .livability:
+                result = (lhs.livability ?? -1) < (rhs.livability ?? -1)
+            }
+            return ascending ? result : !result
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Dashboard/DashboardView.swift
+++ b/ios/FarmManagementApp/Features/Dashboard/DashboardView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import FarmManagementCore
+
+struct DashboardView: View {
+    @StateObject private var viewModel = DashboardViewModel(farmService: AppContainer.shared.farmService)
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch viewModel.state {
+                case .idle, .loading:
+                    ProgressView("Loading dashboard...")
+                case .failed(let message):
+                    ErrorStateView(
+                        title: "Could not load dashboard",
+                        systemImage: "exclamationmark.triangle",
+                        message: message
+                    )
+                case .loaded(let farms):
+                    ScrollView {
+                        let active = farms.filter(\.isActive).count
+                        let houses = farms.compactMap(\.totalHouses).reduce(0, +)
+                        let integrated = farms.filter { $0.isIntegrated == true }.count
+
+                        VStack(alignment: .leading, spacing: 14) {
+                            Text("Overview")
+                                .font(.title3.bold())
+                            HStack(spacing: 12) {
+                                statCard(title: "Active Farms", value: "\(active)", systemImage: "leaf.fill")
+                                statCard(title: "Total Houses", value: "\(houses)", systemImage: "house.fill")
+                            }
+                            statCard(title: "Integrated Farms", value: "\(integrated)", systemImage: "bolt.horizontal.fill")
+                        }
+                        .padding()
+                    }
+                    .refreshable { await viewModel.load() }
+                }
+            }
+            .navigationTitle("Dashboard")
+            .navigationBarTitleDisplayMode(.large)
+            .task {
+                if case .idle = viewModel.state {
+                    await viewModel.load()
+                }
+            }
+        }
+    }
+
+    private func statCard(title: String, value: String, systemImage: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: systemImage)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+    }
+}

--- a/ios/FarmManagementApp/Features/Dashboard/DashboardViewModel.swift
+++ b/ios/FarmManagementApp/Features/Dashboard/DashboardViewModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+import FarmManagementCore
+
+@MainActor
+final class DashboardViewModel: ObservableObject {
+    @Published var state: LoadableState<[FarmSummary]> = .idle
+
+    private let farmService: FarmService
+
+    init(farmService: FarmService) {
+        self.farmService = farmService
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let farms = try await farmService.fetchFarms()
+            state = .loaded(farms)
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load dashboard")
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Farms/FarmDetailView.swift
+++ b/ios/FarmManagementApp/Features/Farms/FarmDetailView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import FarmManagementCore
+
+struct FarmDetailView: View {
+    @StateObject private var viewModel: FarmDetailViewModel
+
+    init(farmID: Int) {
+        _viewModel = StateObject(
+            wrappedValue: FarmDetailViewModel(
+                farmID: farmID,
+                service: AppContainer.shared.farmService
+            )
+        )
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView("Loading farm detail...")
+            case .failed(let message):
+                ErrorStateView(
+                    title: "Unable to load farm",
+                    systemImage: "exclamationmark.triangle",
+                    message: message
+                )
+            case .loaded(let farm):
+                List {
+                    Section("Summary") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(farm.name)
+                                .font(.title3.bold())
+                            Text(farm.location ?? "-")
+                                .foregroundStyle(.secondary)
+                            HStack(spacing: 16) {
+                                Label("\(farm.totalHouses ?? 0) houses", systemImage: "house.fill")
+                                Label("\(farm.activeHouses ?? 0) active", systemImage: "checkmark.circle.fill")
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    Section("Insights") {
+                        NavigationLink {
+                            FarmMonitoringView(farmID: farm.id)
+                        } label: {
+                            Label("Realtime Monitoring", systemImage: "waveform.path.ecg")
+                        }
+                        NavigationLink {
+                            FarmComparisonView(farmID: farm.id)
+                        } label: {
+                            Label("House Comparison", systemImage: "chart.bar.xaxis")
+                        }
+                    }
+                    Section("Houses") {
+                        ForEach(farm.houses) { house in
+                            NavigationLink {
+                                HouseDetailView(houseID: house.id)
+                            } label: {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("House \(house.houseNumber)")
+                                    Text(house.status ?? "Unknown")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Farm Detail")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if case .idle = viewModel.state {
+                await viewModel.load()
+            }
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Farms/FarmDetailViewModel.swift
+++ b/ios/FarmManagementApp/Features/Farms/FarmDetailViewModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+import FarmManagementCore
+
+@MainActor
+final class FarmDetailViewModel: ObservableObject {
+    @Published var state: LoadableState<FarmDetail> = .idle
+
+    private let farmID: Int
+    private let service: FarmService
+
+    init(farmID: Int, service: FarmService) {
+        self.farmID = farmID
+        self.service = service
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            state = .loaded(try await service.fetchFarmDetail(id: farmID))
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load farm details")
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Farms/FarmListView.swift
+++ b/ios/FarmManagementApp/Features/Farms/FarmListView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import FarmManagementCore
+
+struct FarmListView: View {
+    @StateObject private var viewModel = FarmListViewModel(farmService: AppContainer.shared.farmService)
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch viewModel.state {
+                case .idle, .loading:
+                    ProgressView("Loading farms...")
+                case .failed(let message):
+                    ErrorStateView(
+                        title: "Unable to load farms",
+                        systemImage: "exclamationmark.circle",
+                        message: message
+                    )
+                case .loaded:
+                    List(viewModel.filteredFarms) { farm in
+                        NavigationLink {
+                            FarmDetailView(farmID: farm.id)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 10) {
+                                HStack {
+                                    Text(farm.name).font(.headline)
+                                    Spacer()
+                                    if farm.isIntegrated == true {
+                                        Label("Integrated", systemImage: "bolt.fill")
+                                            .font(.caption)
+                                            .foregroundStyle(.green)
+                                    }
+                                }
+                                Text(farm.location ?? "No location")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                HStack(spacing: 12) {
+                                    Label("\(farm.totalHouses ?? 0) houses", systemImage: "house")
+                                    Label("\(farm.activeHouses ?? 0) active", systemImage: "checkmark.circle")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 6)
+                        }
+                    }
+                    .searchable(text: $viewModel.query, prompt: "Search farms")
+                    .refreshable { await viewModel.load() }
+                }
+            }
+            .navigationTitle("Farms")
+            .navigationBarTitleDisplayMode(.large)
+            .task {
+                if case .idle = viewModel.state {
+                    await viewModel.load()
+                }
+            }
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Farms/FarmListViewModel.swift
+++ b/ios/FarmManagementApp/Features/Farms/FarmListViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+import FarmManagementCore
+
+@MainActor
+final class FarmListViewModel: ObservableObject {
+    @Published var state: LoadableState<[FarmSummary]> = .idle
+    @Published var query = ""
+
+    private let farmService: FarmService
+
+    init(farmService: FarmService) {
+        self.farmService = farmService
+    }
+
+    var filteredFarms: [FarmSummary] {
+        guard case .loaded(let farms) = state, query.isEmpty == false else {
+            if case .loaded(let farms) = state { return farms }
+            return []
+        }
+        return farms.filter { farm in
+            farm.name.localizedCaseInsensitiveContains(query) ||
+            (farm.location ?? "").localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            let farms = try await farmService.fetchFarms()
+            state = .loaded(farms)
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load farms")
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Houses/HouseDetailView.swift
+++ b/ios/FarmManagementApp/Features/Houses/HouseDetailView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import FarmManagementCore
+
+struct HouseDetailView: View {
+    @StateObject private var viewModel: HouseDetailViewModel
+
+    init(houseID: Int) {
+        _viewModel = StateObject(
+            wrappedValue: HouseDetailViewModel(
+                houseID: houseID,
+                service: AppContainer.shared.houseService
+            )
+        )
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView("Loading house detail...")
+            case .failed(let message):
+                ErrorStateView(
+                    title: "Unable to load house",
+                    systemImage: "exclamationmark.triangle",
+                    message: message
+                )
+            case .loaded(let data):
+                List {
+                    Section("Overview") {
+                        LabeledContent("House number", value: "\(data.house.houseNumber)")
+                        LabeledContent("Status", value: data.house.status ?? "-")
+                        LabeledContent("Age (days)", value: "\(data.house.ageDays ?? data.house.currentAgeDays ?? 0)")
+                        LabeledContent("Days remaining", value: "\(data.house.daysRemaining ?? 0)")
+                        LabeledContent("Active alarms", value: "\(data.activeAlarmsCount)")
+                    }
+                    Section("Batch") {
+                        LabeledContent("Start date", value: data.house.batchStartDate ?? "-")
+                        LabeledContent("Expected harvest", value: data.house.expectedHarvestDate ?? "-")
+                        LabeledContent("Integrated", value: data.house.isIntegrated ? "Yes" : "No")
+                    }
+                    if let stats = data.stats {
+                        Section("7-Day Trends") {
+                            statRow("Temperature", stats.temperature)
+                            statRow("Humidity", stats.humidity)
+                            statRow("Pressure", stats.pressure)
+                        }
+                    }
+                    if let kpis = data.kpis {
+                        Section("Operational Deltas") {
+                            LabeledContent("Water DoD", value: deltaText(kpis.waterDayOverDay))
+                            LabeledContent("Feed DoD", value: deltaText(kpis.feedDayOverDay))
+                            LabeledContent("Water:Feed ratio", value: ratioText(kpis.waterFeedRatio.today))
+                        }
+                        Section("Runtime Proxies (24h)") {
+                            LabeledContent("Heater runtime", value: runtimeText(kpis.heaterRuntime.hours24h))
+                            LabeledContent("Fan runtime", value: runtimeText(kpis.fanRuntime.hours24h))
+                            LabeledContent("Heater cycles", value: "\(kpis.heaterRuntime.cycles24h ?? 0)")
+                            LabeledContent("Ventilation effort", value: ratioText(kpis.ventilationEffortIndex))
+                        }
+                    }
+                    if let wind = data.wind {
+                        Section("Wind Context") {
+                            LabeledContent("Wind speed", value: ratioText(wind.windSpeed))
+                            LabeledContent("Wind direction", value: ratioText(wind.windDirection))
+                            LabeledContent("Wind chill", value: ratioText(wind.windChillTemperature))
+                        }
+                    }
+                    if let water = data.latestWaterBreakdown {
+                        Section("Water Breakdown (latest)") {
+                            LabeledContent("Growth day", value: "\(water.growthDay ?? 0)")
+                            LabeledContent("Drink line 1", value: ratioText(water.dailyWater1))
+                            LabeledContent("Drink line 2", value: ratioText(water.dailyWater2))
+                            LabeledContent("Drink line 3", value: ratioText(water.dailyWater3))
+                            LabeledContent("Drink line 4", value: ratioText(water.dailyWater4))
+                            LabeledContent("Cooling", value: ratioText(water.cooling))
+                            LabeledContent("Fogger", value: ratioText(water.fogger))
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("House Detail")
+        .task {
+            if case .idle = viewModel.state {
+                await viewModel.load()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func statRow(_ title: String, _ range: StatRange?) -> some View {
+        LabeledContent(title, value: "avg \(ratioText(range?.avg)) / max \(ratioText(range?.max)) / min \(ratioText(range?.min))")
+    }
+
+    private func deltaText(_ metric: DeltaMetric) -> String {
+        guard let delta = metric.delta, let deltaPct = metric.deltaPct else { return "N/A" }
+        return String(format: "%+.1f (%+.1f%%)", delta, deltaPct)
+    }
+
+    private func runtimeText(_ hours: Double?) -> String {
+        guard let hours else { return "N/A" }
+        return String(format: "%.2f h", hours)
+    }
+
+    private func ratioText(_ value: Double?) -> String {
+        guard let value else { return "N/A" }
+        return String(format: "%.2f", value)
+    }
+}

--- a/ios/FarmManagementApp/Features/Houses/HouseDetailViewModel.swift
+++ b/ios/FarmManagementApp/Features/Houses/HouseDetailViewModel.swift
@@ -1,0 +1,50 @@
+import Foundation
+import FarmManagementCore
+
+struct HouseDetailScreenData {
+    let house: HouseDetail
+    let stats: HouseStats?
+    let kpis: HouseMonitoringKpisResponse?
+    let wind: WindContext?
+    let latestWaterBreakdown: WaterHistoryEntry?
+    let activeAlarmsCount: Int
+}
+
+@MainActor
+final class HouseDetailViewModel: ObservableObject {
+    @Published var state: LoadableState<HouseDetailScreenData> = .idle
+
+    private let houseID: Int
+    private let service: HouseService
+
+    init(houseID: Int, service: HouseService) {
+        self.houseID = houseID
+        self.service = service
+    }
+
+    func load() async {
+        state = .loading
+        do {
+            async let baseDetail = service.fetchHouseDetail(id: houseID)
+            async let details = service.fetchHouseDetails(id: houseID)
+
+            let house = try await baseDetail
+            let detailed = try await details
+
+            let kpis = try? await service.fetchHouseMonitoringKpis(id: houseID)
+            let waterHistory = try? await service.fetchHouseWaterHistory(id: houseID)
+
+            let screen = HouseDetailScreenData(
+                house: house,
+                stats: detailed.stats,
+                kpis: kpis,
+                wind: detailed.monitoring?.sensorData?.wind,
+                latestWaterBreakdown: waterHistory?.waterHistory.first,
+                activeAlarmsCount: detailed.alarms.count
+            )
+            state = .loaded(screen)
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load house details")
+        }
+    }
+}

--- a/ios/FarmManagementApp/Features/Monitoring/FarmMonitoringView.swift
+++ b/ios/FarmManagementApp/Features/Monitoring/FarmMonitoringView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import FarmManagementCore
+
+struct FarmMonitoringView: View {
+    @StateObject private var viewModel: FarmMonitoringViewModel
+
+    init(farmID: Int) {
+        _viewModel = StateObject(
+            wrappedValue: FarmMonitoringViewModel(
+                farmID: farmID,
+                service: AppContainer.shared.farmService
+            )
+        )
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle, .loading:
+                ProgressView("Loading monitoring...")
+            case .failed(let message):
+                ErrorStateView(
+                    title: "Unable to load monitoring",
+                    systemImage: "exclamationmark.triangle",
+                    message: message
+                )
+            case .loaded(let data):
+                List {
+                    Section("Overview") {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(data.farmName).font(.headline)
+                            HStack(spacing: 14) {
+                                Label("\(data.housesCount) houses", systemImage: "house.fill")
+                                Label("Updated \(formattedUpdateTime(viewModel.lastUpdatedAt))", systemImage: "clock")
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Section("Houses") {
+                        ForEach(data.houses) { house in
+                            VStack(alignment: .leading, spacing: 6) {
+                                HStack {
+                                    Text("House \(house.houseNumber)")
+                                        .font(.headline)
+                                    Spacer()
+                                    if house.status == "no_data" {
+                                        Text("No Data")
+                                            .font(.caption2.bold())
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 4)
+                                            .background(Color.gray.opacity(0.15), in: Capsule())
+                                    } else {
+                                        Text(house.alarmStatus ?? "normal")
+                                            .font(.caption2.bold())
+                                            .padding(.horizontal, 8)
+                                            .padding(.vertical, 4)
+                                            .background((house.alarmStatus == "critical" ? Color.red.opacity(0.15) : Color.green.opacity(0.15)), in: Capsule())
+                                            .foregroundStyle((house.alarmStatus == "critical") ? .red : .green)
+                                    }
+                                }
+                                HStack(spacing: 12) {
+                                    Label(house.isConnected == true ? "Connected" : "Disconnected", systemImage: house.isConnected == true ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    Label("Active alarms: \(viewModel.activeAlarmCounts[house.id] ?? 0)", systemImage: "bell.badge")
+                                    Label("Freshness: \(freshnessText(for: house.timestamp))", systemImage: "clock.arrow.circlepath")
+                                }
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                HStack {
+                                    metric("Temp", house.averageTemperature, unit: "F")
+                                    metric("Humidity", house.humidity, unit: "%")
+                                    metric("Pressure", house.staticPressure, unit: "")
+                                    metric("Day", house.growthDay.map(Double.init), unit: "")
+                                }
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+                .refreshable { await viewModel.refresh() }
+            }
+        }
+        .navigationTitle("Realtime Monitoring")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            if case .idle = viewModel.state {
+                await viewModel.loadInitial()
+            }
+            viewModel.startPolling()
+        }
+        .onDisappear {
+            viewModel.stopPolling()
+        }
+    }
+
+    private func metric(_ name: String, _ value: Double?, unit: String) -> some View {
+        Text("\(name): \(formatted(value, unit: unit))")
+    }
+
+    private func formatted(_ value: Double?, unit: String) -> String {
+        guard let value else { return "---" }
+        if unit.isEmpty { return String(format: "%.0f", value) }
+        return String(format: "%.1f%@", value, unit)
+    }
+
+    private func formattedUpdateTime(_ date: Date?) -> String {
+        guard let date else { return "-" }
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        return formatter.string(from: date)
+    }
+
+    private func freshnessText(for timestamp: String?) -> String {
+        guard let timestamp,
+              let parsed = ISO8601DateFormatter().date(from: timestamp) else {
+            return "Unknown"
+        }
+        let minutes = Int(Date().timeIntervalSince(parsed) / 60)
+        if minutes < 2 { return "Live" }
+        if minutes < 15 { return "\(minutes)m" }
+        return "\(minutes)m (stale)"
+    }
+}

--- a/ios/FarmManagementApp/Features/Monitoring/FarmMonitoringViewModel.swift
+++ b/ios/FarmManagementApp/Features/Monitoring/FarmMonitoringViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import FarmManagementCore
+
+@MainActor
+final class FarmMonitoringViewModel: ObservableObject {
+    @Published var state: LoadableState<FarmMonitoringResponse> = .idle
+    @Published var lastUpdatedAt: Date?
+    @Published var activeAlarmCounts: [Int: Int] = [:]
+
+    private let farmID: Int
+    private let service: FarmService
+    private var pollTask: Task<Void, Never>?
+
+    init(farmID: Int, service: FarmService) {
+        self.farmID = farmID
+        self.service = service
+    }
+
+    deinit {
+        pollTask?.cancel()
+    }
+
+    func loadInitial() async {
+        state = .loading
+        await refresh()
+    }
+
+    func refresh() async {
+        do {
+            async let monitoringResponse = service.fetchFarmMonitoring(farmID: farmID)
+            async let dashboardResponse = service.fetchFarmMonitoringDashboard(farmID: farmID)
+
+            let response = try await monitoringResponse
+            let dashboard = try await dashboardResponse
+
+            state = .loaded(response)
+            activeAlarmCounts = Dictionary(uniqueKeysWithValues: dashboard.houses.map { ($0.id, $0.activeAlarmsCount ?? 0) })
+            lastUpdatedAt = Date()
+        } catch {
+            state = .failed((error as? LocalizedError)?.errorDescription ?? "Failed to load monitoring.")
+        }
+    }
+
+    func startPolling() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            while Task.isCancelled == false {
+                try? await Task.sleep(nanoseconds: 30_000_000_000)
+                guard Task.isCancelled == false else { break }
+                await self?.refresh()
+            }
+        }
+    }
+
+    func stopPolling() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+}

--- a/ios/FarmManagementApp/Features/RootView.swift
+++ b/ios/FarmManagementApp/Features/RootView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        Group {
+            if appState.isAuthenticated {
+                MainTabView()
+            } else {
+                LoginView()
+            }
+        }
+    }
+}
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem {
+                    Label("Dashboard", systemImage: "chart.bar.fill")
+                }
+            FarmListView()
+                .tabItem {
+                    Label("Farms", systemImage: "leaf.fill")
+                }
+            SessionView()
+                .tabItem {
+                    Label("Session", systemImage: "person.crop.circle")
+                }
+        }
+        .tint(.green)
+    }
+}
+
+struct SessionView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Environment") {
+                    Text("Deployment: \(AppEnvironment.deploymentTarget)")
+                    Text("Devices: \(AppEnvironment.devicePolicy)")
+                    Text("API: \(AppEnvironment.apiBaseURL.absoluteString)")
+                }
+                Section("Account") {
+                    Text(appState.user?.username ?? "Unknown user")
+                    Button("Logout", role: .destructive) {
+                        appState.logout()
+                    }
+                }
+            }
+            .navigationTitle("Session")
+        }
+    }
+}

--- a/ios/FarmManagementApp/SharedUI/ErrorStateView.swift
+++ b/ios/FarmManagementApp/SharedUI/ErrorStateView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ErrorStateView: View {
+    let title: String
+    let systemImage: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .font(.system(size: 28))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}

--- a/ios/FarmManagementCore/Package.swift
+++ b/ios/FarmManagementCore/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "FarmManagementCore",
+    platforms: [
+        .iOS(.v16),
+        .macOS(.v13)
+    ],
+    products: [
+        .library(
+            name: "FarmManagementCore",
+            targets: ["FarmManagementCore"]
+        ),
+        .executable(
+            name: "ContractCheck",
+            targets: ["ContractCheck"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "FarmManagementCore"
+        ),
+        .executableTarget(
+            name: "ContractCheck",
+            dependencies: ["FarmManagementCore"],
+            path: "Tools/ContractCheck",
+            resources: [.process("Fixtures")]
+        )
+    ]
+)

--- a/ios/FarmManagementCore/Sources/FarmManagementCore/Models.swift
+++ b/ios/FarmManagementCore/Sources/FarmManagementCore/Models.swift
@@ -1,0 +1,531 @@
+import Foundation
+
+public struct AuthUser: Codable, Equatable {
+    public let id: Int
+    public let username: String
+    public let email: String
+    public let isStaff: Bool
+    public let isAuthenticated: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case username
+        case email
+        case isStaff = "is_staff"
+        case isAuthenticated = "is_authenticated"
+    }
+}
+
+public struct LoginResponse: Codable, Equatable {
+    public let message: String?
+    public let token: String
+    public let user: AuthUser
+}
+
+public struct FarmSummary: Codable, Identifiable, Equatable {
+    public let id: Int
+    /// Backend sends a UUID string or null; keep as String to avoid decode failures.
+    public let organization: String?
+    public let name: String
+    public let location: String?
+    public let description: String?
+    public let isActive: Bool
+    public let totalHouses: Int?
+    public let activeHouses: Int?
+    public let isIntegrated: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case organization
+        case name
+        case location
+        case description
+        case isActive = "is_active"
+        case totalHouses = "total_houses"
+        case activeHouses = "active_houses"
+        case isIntegrated = "is_integrated"
+    }
+}
+
+public struct HouseSummary: Codable, Identifiable, Equatable {
+    public let id: Int
+    public let houseNumber: Int
+    public let isIntegrated: Bool?
+    public let currentAgeDays: Int?
+    public let ageDays: Int?
+    public let status: String?
+    public let batchStartDate: String?
+    public let expectedHarvestDate: String?
+    public let isActive: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case houseNumber = "house_number"
+        case isIntegrated = "is_integrated"
+        case currentAgeDays = "current_age_days"
+        case ageDays = "age_days"
+        case status
+        case batchStartDate = "batch_start_date"
+        case expectedHarvestDate = "expected_harvest_date"
+        case isActive = "is_active"
+    }
+}
+
+public struct FarmDetail: Codable, Identifiable, Equatable {
+    public let id: Int
+    public let organization: String?
+    public let name: String
+    public let location: String?
+    public let description: String?
+    public let contactPerson: String?
+    public let contactPhone: String?
+    public let contactEmail: String?
+    public let isActive: Bool
+    public let totalHouses: Int?
+    public let activeHouses: Int?
+    public let houses: [HouseSummary]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case organization
+        case name
+        case location
+        case description
+        case contactPerson = "contact_person"
+        case contactPhone = "contact_phone"
+        case contactEmail = "contact_email"
+        case isActive = "is_active"
+        case totalHouses = "total_houses"
+        case activeHouses = "active_houses"
+        case houses
+    }
+}
+
+public struct HouseDetail: Codable, Identifiable, Equatable {
+    public let id: Int
+    public let houseNumber: Int
+    public let currentDay: Int?
+    public let currentAgeDays: Int?
+    public let ageDays: Int?
+    public let daysRemaining: Int?
+    public let status: String?
+    public let isActive: Bool
+    public let isIntegrated: Bool
+    public let batchStartDate: String?
+    public let expectedHarvestDate: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case houseNumber = "house_number"
+        case currentDay = "current_day"
+        case currentAgeDays = "current_age_days"
+        case ageDays = "age_days"
+        case daysRemaining = "days_remaining"
+        case status
+        case isActive = "is_active"
+        case isIntegrated = "is_integrated"
+        case batchStartDate = "batch_start_date"
+        case expectedHarvestDate = "expected_harvest_date"
+    }
+}
+
+public struct UserInfoResponse: Codable, Equatable {
+    public let user: AuthUser
+}
+
+public struct HouseDetailsResponse: Codable, Equatable {
+    public let house: HouseDetail
+    public let monitoring: HouseMonitoringSnapshot?
+    public let alarms: [HouseAlarmSummary]
+    public let stats: HouseStats?
+}
+
+public struct HouseMonitoringSnapshot: Codable, Equatable {
+    public let id: Int
+    public let timestamp: String?
+    public let averageTemperature: Double?
+    public let outsideTemperature: Double?
+    public let humidity: Double?
+    public let staticPressure: Double?
+    public let targetTemperature: Double?
+    public let ventilationLevel: Double?
+    public let growthDay: Int?
+    public let birdCount: Int?
+    public let livability: Double?
+    public let waterConsumption: Double?
+    public let feedConsumption: Double?
+    public let airflowPercentage: Double?
+    public let sensorData: SnapshotSensorData?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case timestamp
+        case averageTemperature = "average_temperature"
+        case outsideTemperature = "outside_temperature"
+        case humidity
+        case staticPressure = "static_pressure"
+        case targetTemperature = "target_temperature"
+        case ventilationLevel = "ventilation_level"
+        case growthDay = "growth_day"
+        case birdCount = "bird_count"
+        case livability
+        case waterConsumption = "water_consumption"
+        case feedConsumption = "feed_consumption"
+        case airflowPercentage = "airflow_percentage"
+        case sensorData = "sensor_data"
+    }
+}
+
+public struct SnapshotSensorData: Codable, Equatable {
+    public let wind: WindContext?
+}
+
+public struct WindContext: Codable, Equatable {
+    public let windSpeed: Double?
+    public let windDirection: Double?
+    public let windChillTemperature: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case windSpeed = "wind_speed"
+        case windDirection = "wind_direction"
+        case windChillTemperature = "wind_chill_temperature"
+    }
+}
+
+public struct HouseAlarmSummary: Codable, Equatable, Identifiable {
+    public let id: Int
+    public let alarmType: String
+    public let severity: String
+    public let message: String
+    public let timestamp: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case alarmType = "alarm_type"
+        case severity
+        case message
+        case timestamp
+    }
+}
+
+public struct HouseStats: Codable, Equatable {
+    public let temperature: StatRange?
+    public let humidity: StatRange?
+    public let pressure: StatRange?
+}
+
+public struct StatRange: Codable, Equatable {
+    public let avg: Double?
+    public let max: Double?
+    public let min: Double?
+}
+
+public struct HouseMonitoringKpisResponse: Codable, Equatable {
+    public let houseID: Int
+    public let windowHours: Int
+    public let heaterRuntime: HeaterRuntime
+    public let fanRuntime: FanRuntime
+    public let waterDayOverDay: DeltaMetric
+    public let feedDayOverDay: DeltaMetric
+    public let waterFeedRatio: RatioMetric
+    public let ventilationEffortIndex: Double?
+    public let alarmBurden: AlarmBurden
+
+    enum CodingKeys: String, CodingKey {
+        case houseID = "house_id"
+        case windowHours = "window_hours"
+        case heaterRuntime = "heater_runtime"
+        case fanRuntime = "fan_runtime"
+        case waterDayOverDay = "water_day_over_day"
+        case feedDayOverDay = "feed_day_over_day"
+        case waterFeedRatio = "water_feed_ratio"
+        case ventilationEffortIndex = "ventilation_effort_index"
+        case alarmBurden = "alarm_burden"
+    }
+}
+
+public struct HeaterRuntime: Codable, Equatable {
+    public let hours24h: Double?
+    public let cycles24h: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case hours24h = "hours_24h"
+        case cycles24h = "cycles_24h"
+    }
+}
+
+public struct FanRuntime: Codable, Equatable {
+    public let hours24h: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case hours24h = "hours_24h"
+    }
+}
+
+public struct DeltaMetric: Codable, Equatable {
+    public let current: Double?
+    public let previous: Double?
+    public let delta: Double?
+    public let deltaPct: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case current
+        case previous
+        case delta
+        case deltaPct = "delta_pct"
+    }
+}
+
+public struct RatioMetric: Codable, Equatable {
+    public let today: Double?
+    public let yesterday: Double?
+    public let deltaPct: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case today
+        case yesterday
+        case deltaPct = "delta_pct"
+    }
+}
+
+public struct AlarmBurden: Codable, Equatable {
+    public let total24h: Int
+    public let critical24h: Int
+    public let high24h: Int
+    public let medium24h: Int
+    public let low24h: Int
+    public let activeNow: Int
+
+    enum CodingKeys: String, CodingKey {
+        case total24h = "total_24h"
+        case critical24h = "critical_24h"
+        case high24h = "high_24h"
+        case medium24h = "medium_24h"
+        case low24h = "low_24h"
+        case activeNow = "active_now"
+    }
+}
+
+public struct WaterHistoryResponse: Codable, Equatable {
+    public let waterHistory: [WaterHistoryEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case waterHistory = "water_history"
+    }
+}
+
+public struct WaterHistoryEntry: Codable, Equatable, Identifiable {
+    public var id: String { date ?? UUID().uuidString }
+    public let date: String?
+    public let growthDay: Int?
+    public let dailyWater1: Double?
+    public let dailyWater2: Double?
+    public let dailyWater3: Double?
+    public let dailyWater4: Double?
+    public let cooling: Double?
+    public let fogger: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case date
+        case growthDay = "growth_day"
+        case dailyWater1 = "daily_water_1"
+        case dailyWater2 = "daily_water_2"
+        case dailyWater3 = "daily_water_3"
+        case dailyWater4 = "daily_water_4"
+        case cooling
+        case fogger
+    }
+}
+
+public struct FarmMonitoringResponse: Codable, Equatable {
+    public let farmID: Int
+    public let farmName: String
+    public let housesCount: Int
+    public let houses: [FarmMonitoringHouse]
+
+    enum CodingKeys: String, CodingKey {
+        case farmID = "farm_id"
+        case farmName = "farm_name"
+        case housesCount = "houses_count"
+        case houses
+    }
+}
+
+public struct FarmMonitoringHouse: Codable, Identifiable, Equatable {
+    public var id: Int { houseID ?? fallbackID ?? -1 }
+    public let houseID: Int?
+    public let fallbackID: Int?
+    public let houseNumber: Int
+    public let timestamp: String?
+    public let averageTemperature: Double?
+    public let humidity: Double?
+    public let staticPressure: Double?
+    public let growthDay: Int?
+    public let alarmStatus: String?
+    public let connectionStatus: Int?
+    public let hasAlarms: Bool?
+    public let isConnected: Bool?
+    public let status: String?
+    public let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case houseID = "house_id"
+        case fallbackID = "id"
+        case houseNumber = "house_number"
+        case timestamp
+        case averageTemperature = "average_temperature"
+        case humidity
+        case staticPressure = "static_pressure"
+        case growthDay = "growth_day"
+        case alarmStatus = "alarm_status"
+        case connectionStatus = "connection_status"
+        case hasAlarms = "has_alarms"
+        case isConnected = "is_connected"
+        case status
+        case message
+    }
+}
+
+public struct FarmMonitoringDashboardResponse: Codable, Equatable {
+    public let farmID: Int
+    public let farmName: String
+    public let totalHouses: Int
+    public let houses: [FarmMonitoringDashboardHouse]
+    public let alertsSummary: AlertsSummary
+    public let connectionSummary: ConnectionSummary
+
+    enum CodingKeys: String, CodingKey {
+        case farmID = "farm_id"
+        case farmName = "farm_name"
+        case totalHouses = "total_houses"
+        case houses
+        case alertsSummary = "alerts_summary"
+        case connectionSummary = "connection_summary"
+    }
+}
+
+public struct FarmMonitoringDashboardHouse: Codable, Identifiable, Equatable {
+    public let id: Int
+    public let houseNumber: Int
+    public let currentDay: Int?
+    public let status: String?
+    public let timestamp: String?
+    public let averageTemperature: Double?
+    public let humidity: Double?
+    public let staticPressure: Double?
+    public let growthDay: Int?
+    public let alarmStatus: String?
+    public let isConnected: Bool?
+    public let activeAlarmsCount: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case id = "house_id"
+        case houseNumber = "house_number"
+        case currentDay = "current_day"
+        case status
+        case timestamp
+        case averageTemperature = "average_temperature"
+        case humidity
+        case staticPressure = "static_pressure"
+        case growthDay = "growth_day"
+        case alarmStatus = "alarm_status"
+        case isConnected = "is_connected"
+        case activeAlarmsCount = "active_alarms_count"
+    }
+}
+
+public struct AlertsSummary: Codable, Equatable {
+    public let totalActive: Int
+    public let critical: Int
+    public let warning: Int
+    public let normal: Int
+
+    enum CodingKeys: String, CodingKey {
+        case totalActive = "total_active"
+        case critical
+        case warning
+        case normal
+    }
+}
+
+public struct ConnectionSummary: Codable, Equatable {
+    public let connected: Int
+    public let disconnected: Int
+}
+
+public struct HouseComparisonResponse: Codable, Equatable {
+    public let count: Int
+    public let houses: [HouseComparisonItem]
+}
+
+public struct HouseComparisonItem: Codable, Identifiable, Equatable {
+    public let id: Int
+    public let houseNumber: Int
+    public let farmID: Int
+    public let farmName: String
+    public let currentDay: Int?
+    public let ageDays: Int?
+    public let status: String
+    public let isFullHouse: Bool
+    public let lastUpdateTime: String?
+    public let averageTemperature: Double?
+    public let outsideTemperature: Double?
+    public let targetTemperature: Double?
+    public let staticPressure: Double?
+    public let insideHumidity: Double?
+    public let airflowPercentage: Double?
+    public let waterConsumption: Double?
+    public let feedConsumption: Double?
+    public let waterPerBird: Double?
+    public let feedPerBird: Double?
+    public let waterFeedRatio: Double?
+    public let birdCount: Int?
+    public let livability: Double?
+    public let growthDay: Int?
+    public let isConnected: Bool
+    public let hasAlarms: Bool
+    public let alarmStatus: String
+    public let activeAlarmsCount: Int?
+    public let dataFreshnessMinutes: Int?
+    public let heaterOn: Bool?
+    public let fanOn: Bool?
+    public let windSpeed: Double?
+    public let windDirection: Double?
+    public let windChillTemperature: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case id = "house_id"
+        case houseNumber = "house_number"
+        case farmID = "farm_id"
+        case farmName = "farm_name"
+        case currentDay = "current_day"
+        case ageDays = "age_days"
+        case status
+        case isFullHouse = "is_full_house"
+        case lastUpdateTime = "last_update_time"
+        case averageTemperature = "average_temperature"
+        case outsideTemperature = "outside_temperature"
+        case targetTemperature = "target_temperature"
+        case staticPressure = "static_pressure"
+        case insideHumidity = "inside_humidity"
+        case airflowPercentage = "airflow_percentage"
+        case waterConsumption = "water_consumption"
+        case feedConsumption = "feed_consumption"
+        case waterPerBird = "water_per_bird"
+        case feedPerBird = "feed_per_bird"
+        case waterFeedRatio = "water_feed_ratio"
+        case birdCount = "bird_count"
+        case livability
+        case growthDay = "growth_day"
+        case isConnected = "is_connected"
+        case hasAlarms = "has_alarms"
+        case alarmStatus = "alarm_status"
+        case activeAlarmsCount = "active_alarms_count"
+        case dataFreshnessMinutes = "data_freshness_minutes"
+        case heaterOn = "heater_on"
+        case fanOn = "fan_on"
+        case windSpeed = "wind_speed"
+        case windDirection = "wind_direction"
+        case windChillTemperature = "wind_chill_temperature"
+    }
+}

--- a/ios/FarmManagementCore/Sources/FarmManagementCore/Networking.swift
+++ b/ios/FarmManagementCore/Sources/FarmManagementCore/Networking.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+public enum APIError: LocalizedError, Equatable {
+    case invalidURL
+    case transport(String)
+    case unauthorized
+    case server(statusCode: Int, message: String)
+    case decoding(String)
+    case unknown
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            return "Invalid API URL."
+        case .transport(let message):
+            return "Network error: \(message)"
+        case .unauthorized:
+            return "Your session is invalid. Please log in again."
+        case .server(_, let message):
+            return message
+        case .decoding(let message):
+            return "Failed to parse server response: \(message)"
+        case .unknown:
+            return "An unknown error occurred."
+        }
+    }
+}
+
+public struct APIMessageError: Decodable {
+    public let message: String?
+    public let error: String?
+    public let detail: String?
+}
+
+public struct PaginatedResponse<T: Decodable>: Decodable {
+    public let count: Int
+    public let next: String?
+    public let previous: String?
+    public let results: [T]
+}
+
+public enum FlexibleListResponse<T: Decodable>: Decodable {
+    case paginated(PaginatedResponse<T>)
+    case array([T])
+
+    public var values: [T] {
+        switch self {
+        case .paginated(let paginated):
+            return paginated.results
+        case .array(let array):
+            return array
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let paginated = try? container.decode(PaginatedResponse<T>.self) {
+            self = .paginated(paginated)
+            return
+        }
+        self = .array(try container.decode([T].self))
+    }
+}
+
+public protocol TokenProvider {
+    func readToken() -> String?
+}
+
+public struct APIClient {
+    public let baseURL: URL
+    public let session: URLSession
+    public let tokenProvider: TokenProvider?
+    public var decoder: JSONDecoder
+
+    public init(
+        baseURL: URL,
+        session: URLSession = .shared,
+        tokenProvider: TokenProvider? = nil
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.tokenProvider = tokenProvider
+        self.decoder = JSONDecoder()
+    }
+
+    public func request<T: Decodable>(
+        path: String,
+        method: String = "GET",
+        body: Data? = nil,
+        authenticated: Bool = true
+    ) async throws -> T {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw APIError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.httpBody = body
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if authenticated, let token = tokenProvider?.readToken(), token.isEmpty == false {
+            request.setValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw APIError.transport(error.localizedDescription)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw APIError.unknown
+        }
+
+        if http.statusCode == 401 {
+            throw APIError.unauthorized
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let message: String
+            if let apiError = try? decoder.decode(APIMessageError.self, from: data) {
+                message = apiError.error ?? apiError.message ?? apiError.detail ?? "Server error (\(http.statusCode))"
+            } else if let text = String(data: data, encoding: .utf8), text.isEmpty == false {
+                message = "Server error (\(http.statusCode)): \(text)"
+            } else {
+                message = "Server error (\(http.statusCode))"
+            }
+            throw APIError.server(statusCode: http.statusCode, message: message)
+        }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw APIError.decoding(error.localizedDescription)
+        }
+    }
+}

--- a/ios/FarmManagementCore/Sources/FarmManagementCore/Services.swift
+++ b/ios/FarmManagementCore/Sources/FarmManagementCore/Services.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+public final class AuthService {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func login(username: String, password: String) async throws -> LoginResponse {
+        let payload = ["username": username, "password": password]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        return try await client.request(path: "auth/login/", method: "POST", body: data, authenticated: false)
+    }
+
+    public func currentUser() async throws -> AuthUser {
+        let response: UserInfoResponse = try await client.request(path: "auth/user/")
+        return response.user
+    }
+}
+
+public final class FarmService {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func fetchFarms() async throws -> [FarmSummary] {
+        let response: FlexibleListResponse<FarmSummary> = try await client.request(path: "farms/")
+        return response.values
+    }
+
+    public func fetchFarmDetail(id: Int) async throws -> FarmDetail {
+        do {
+            return try await client.request(path: "farms/\(id)/")
+        } catch APIError.server(let statusCode, _) where statusCode >= 500 || statusCode == 404 {
+            do {
+                // Backend has both router and legacy farm endpoints; fall back when detail route fails.
+                return try await client.request(path: "farms-legacy/\(id)/")
+            } catch APIError.server(let legacyStatusCode, _) where legacyStatusCode == 404 {
+                // Final fallback: reconstruct detail from list + farm houses endpoint.
+                let farms = try await fetchFarms()
+                guard let farm = farms.first(where: { $0.id == id }) else {
+                    throw APIError.server(statusCode: 404, message: "Farm \(id) not found in current farm list.")
+                }
+                let houses = try await fetchFarmHouses(farmID: id)
+                return FarmDetail(
+                    id: farm.id,
+                    organization: farm.organization,
+                    name: farm.name,
+                    location: farm.location,
+                    description: farm.description,
+                    contactPerson: nil,
+                    contactPhone: nil,
+                    contactEmail: nil,
+                    isActive: farm.isActive,
+                    totalHouses: farm.totalHouses,
+                    activeHouses: farm.activeHouses,
+                    houses: houses
+                )
+            }
+        }
+    }
+
+    private func fetchFarmHouses(farmID: Int) async throws -> [HouseSummary] {
+        let response: FlexibleListResponse<HouseSummary> = try await client.request(path: "farms/\(farmID)/houses/")
+        return response.values
+    }
+
+    public func fetchFarmMonitoring(farmID: Int) async throws -> FarmMonitoringResponse {
+        try await client.request(path: "farms/\(farmID)/houses/monitoring/all/")
+    }
+
+    public func fetchFarmMonitoringDashboard(farmID: Int) async throws -> FarmMonitoringDashboardResponse {
+        try await client.request(path: "farms/\(farmID)/houses/monitoring/dashboard/")
+    }
+
+    public func fetchFarmComparison(farmID: Int) async throws -> HouseComparisonResponse {
+        try await client.request(path: "houses/comparison/?farm_id=\(farmID)")
+    }
+}
+
+public final class HouseService {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func fetchHouseDetail(id: Int) async throws -> HouseDetail {
+        try await client.request(path: "houses/\(id)/")
+    }
+
+    public func fetchHouseDetails(id: Int) async throws -> HouseDetailsResponse {
+        try await client.request(path: "houses/\(id)/details/")
+    }
+
+    public func fetchHouseMonitoringKpis(id: Int) async throws -> HouseMonitoringKpisResponse {
+        try await client.request(path: "houses/\(id)/monitoring/kpis/")
+    }
+
+    public func fetchHouseWaterHistory(id: Int) async throws -> WaterHistoryResponse {
+        try await client.request(path: "rotem/daily-summaries/water-history/?house_id=\(id)")
+    }
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farm_monitoring.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farm_monitoring.json
@@ -1,0 +1,26 @@
+{
+  "farm_id": 12,
+  "farm_name": "Farm Alpha",
+  "houses_count": 2,
+  "houses": [
+    {
+      "id": 101,
+      "house_number": 1,
+      "timestamp": "2026-04-07T09:00:00Z",
+      "average_temperature": 32.4,
+      "humidity": 61.2,
+      "static_pressure": 0.12,
+      "growth_day": 19,
+      "alarm_status": "normal",
+      "connection_status": 1,
+      "has_alarms": false,
+      "is_connected": true
+    },
+    {
+      "house_id": 102,
+      "house_number": 2,
+      "status": "no_data",
+      "message": "No monitoring data available"
+    }
+  ]
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farms_array.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farms_array.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": 30,
+    "organization": null,
+    "name": "Farm Gamma",
+    "location": "District C",
+    "description": "Legacy endpoint format",
+    "is_active": true,
+    "total_houses": 3,
+    "active_houses": 2,
+    "is_integrated": false
+  }
+]

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farms_paginated.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/farms_paginated.json
@@ -1,0 +1,29 @@
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 12,
+      "organization": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+      "name": "Farm Alpha",
+      "location": "District A",
+      "description": "Primary location",
+      "is_active": true,
+      "total_houses": 4,
+      "active_houses": 4,
+      "is_integrated": true
+    },
+    {
+      "id": 13,
+      "organization": null,
+      "name": "Farm Beta",
+      "location": "District B",
+      "description": null,
+      "is_active": true,
+      "total_houses": 2,
+      "active_houses": 1,
+      "is_integrated": false
+    }
+  ]
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/house_comparison.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/house_comparison.json
@@ -1,0 +1,53 @@
+{
+  "count": 2,
+  "houses": [
+    {
+      "house_id": 101,
+      "house_number": 1,
+      "farm_id": 12,
+      "farm_name": "Farm Alpha",
+      "current_day": 19,
+      "age_days": 19,
+      "status": "growth",
+      "is_full_house": true,
+      "last_update_time": "2026-04-07T09:00:00Z",
+      "average_temperature": 32.4,
+      "outside_temperature": 28.1,
+      "target_temperature": 31.5,
+      "static_pressure": 0.12,
+      "inside_humidity": 61.2,
+      "water_consumption": 1240.0,
+      "feed_consumption": 980.0,
+      "bird_count": 985,
+      "livability": 98.5,
+      "growth_day": 19,
+      "is_connected": true,
+      "has_alarms": false,
+      "alarm_status": "normal"
+    },
+    {
+      "house_id": 102,
+      "house_number": 2,
+      "farm_id": 12,
+      "farm_name": "Farm Alpha",
+      "current_day": 21,
+      "age_days": 21,
+      "status": "maturation",
+      "is_full_house": true,
+      "last_update_time": "2026-04-07T09:05:00Z",
+      "average_temperature": 33.1,
+      "outside_temperature": 29.0,
+      "target_temperature": 31.0,
+      "static_pressure": 0.11,
+      "inside_humidity": 59.8,
+      "water_consumption": 1320.0,
+      "feed_consumption": 1035.0,
+      "bird_count": 972,
+      "livability": 97.2,
+      "growth_day": 21,
+      "is_connected": true,
+      "has_alarms": true,
+      "alarm_status": "warning"
+    }
+  ]
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/house_detail.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/house_detail.json
@@ -1,0 +1,13 @@
+{
+  "id": 99,
+  "house_number": 5,
+  "current_day": 19,
+  "current_age_days": 19,
+  "age_days": 19,
+  "days_remaining": 21,
+  "status": "active",
+  "is_active": true,
+  "is_integrated": false,
+  "batch_start_date": "2026-03-18",
+  "expected_harvest_date": "2026-05-01"
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/login_response.json
+++ b/ios/FarmManagementCore/Tools/ContractCheck/Fixtures/login_response.json
@@ -1,0 +1,11 @@
+{
+  "message": "Login successful",
+  "token": "sample-token",
+  "user": {
+    "id": 8,
+    "username": "manager",
+    "email": "manager@example.com",
+    "is_staff": false,
+    "is_authenticated": true
+  }
+}

--- a/ios/FarmManagementCore/Tools/ContractCheck/main.swift
+++ b/ios/FarmManagementCore/Tools/ContractCheck/main.swift
@@ -1,0 +1,58 @@
+import Foundation
+import FarmManagementCore
+
+let decoder = JSONDecoder()
+let bundle = Bundle.module
+
+func loadFixture(_ name: String) throws -> Data {
+    guard let url = bundle.url(forResource: name, withExtension: "json") else {
+        throw APIError.decoding("Missing fixture \(name)")
+    }
+    return try Data(contentsOf: url)
+}
+
+func runChecks() throws {
+    let farmsPaginatedData = try loadFixture("farms_paginated")
+    let farmsPaginated = try decoder.decode(FlexibleListResponse<FarmSummary>.self, from: farmsPaginatedData)
+    guard farmsPaginated.values.count == 2 else {
+        throw APIError.decoding("Expected 2 farms in paginated fixture")
+    }
+
+    let farmsArrayData = try loadFixture("farms_array")
+    let farmsArray = try decoder.decode(FlexibleListResponse<FarmSummary>.self, from: farmsArrayData)
+    guard farmsArray.values.first?.id == 30 else {
+        throw APIError.decoding("Expected farm id 30 in array fixture")
+    }
+
+    let loginData = try loadFixture("login_response")
+    let login = try decoder.decode(LoginResponse.self, from: loginData)
+    guard login.token == "sample-token" else {
+        throw APIError.decoding("Unexpected login token in fixture")
+    }
+
+    let houseData = try loadFixture("house_detail")
+    let house = try decoder.decode(HouseDetail.self, from: houseData)
+    guard house.houseNumber == 5, house.ageDays == 19 else {
+        throw APIError.decoding("Unexpected house detail fixture values")
+    }
+
+    let monitoringData = try loadFixture("farm_monitoring")
+    let monitoring = try decoder.decode(FarmMonitoringResponse.self, from: monitoringData)
+    guard monitoring.housesCount == 2, monitoring.houses.first?.houseNumber == 1 else {
+        throw APIError.decoding("Unexpected farm monitoring fixture values")
+    }
+
+    let comparisonData = try loadFixture("house_comparison")
+    let comparison = try decoder.decode(HouseComparisonResponse.self, from: comparisonData)
+    guard comparison.count == 2, comparison.houses.first?.farmID == 12 else {
+        throw APIError.decoding("Unexpected house comparison fixture values")
+    }
+}
+
+do {
+    try runChecks()
+    print("ContractCheck passed: fixture decoding succeeded.")
+} catch {
+    fputs("ContractCheck failed: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/ios/QA_READONLY_CHECKLIST.md
+++ b/ios/QA_READONLY_CHECKLIST.md
@@ -1,0 +1,26 @@
+# Read-Only MVP QA Checklist
+
+## Organization Scoping
+
+- Login as user from Organization A and verify only Organization A farms appear.
+- Confirm farm detail only shows houses assigned through backend membership rules.
+- Attempt direct navigation to unknown farm/house IDs and verify access is denied gracefully.
+
+## Screen Behavior
+
+- Dashboard loads summary counts and supports pull-to-refresh.
+- Farm list loads, search works, empty state appears when no farms exist.
+- Farm detail loads summary and houses list.
+- House detail overview shows age/status/batch fields and handles null values.
+
+## Error and Session Handling
+
+- Invalid credentials show login error.
+- Expired/invalid token forces logout path (`401` handling).
+- Offline mode shows clear error and supports retry.
+
+## Build/Distribution Gate
+
+- Run decoder fixtures locally before each beta.
+- Test on at least one physical iPhone and one simulator.
+- Archive succeeds for Release with `API_BASE_URL_RELEASE` configured.

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,29 @@
+# FarmManagement iOS
+
+Native iOS app migration workspace for the farm management platform.
+
+## Phase 1 Defaults
+
+- Deployment target: `iOS 16.0+`
+- Device support: `iPhone` first (iPad can be enabled in a later phase)
+- UI framework: `SwiftUI`
+- Architecture: `MVVM` with feature modules
+- Auth: backend token auth using `Authorization: Token <token>`
+
+## Structure
+
+- `FarmManagementApp/`: SwiftUI app sources
+- `FarmManagementCore/`: shared networking/domain package and tests
+- `fastlane/`: beta distribution automation
+
+## Setup
+
+1. Install Xcode 15+.
+2. Open the `ios` folder in Xcode as a workspace root.
+3. Add an iOS App target named `FarmManagementApp` and point its source root to `ios/FarmManagementApp`.
+4. Add local package dependency from `ios/FarmManagementCore`.
+5. Create build settings:
+   - `API_BASE_URL_DEBUG`
+   - `API_BASE_URL_RELEASE`
+
+Environment values are read in `FarmManagementApp/Core/AppEnvironment.swift`.

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,5 @@
+app_identifier("com.farmmanagement.ios")
+apple_id("ios-release@your-company.com")
+
+# Team ID should be configured in CI secrets or local env.
+# team_id("YOUR_TEAM_ID")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,21 @@
+default_platform(:ios)
+
+platform :ios do
+  desc "Run core package tests before beta"
+  lane :core_tests do
+    sh("swift run --package-path ios/FarmManagementCore ContractCheck")
+  end
+
+  desc "Build and upload internal TestFlight beta"
+  lane :internal_beta do
+    core_tests
+    build_app(
+      scheme: "FarmManagementApp",
+      export_method: "app-store"
+    )
+    upload_to_testflight(
+      distribute_external: false,
+      skip_waiting_for_build_processing: true
+    )
+  end
+end

--- a/scripts/generate_ios_xcodeproj.rb
+++ b/scripts/generate_ios_xcodeproj.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+require "xcodeproj"
+require "fileutils"
+
+ROOT = File.expand_path("..", __dir__)
+IOS_DIR = File.join(ROOT, "ios")
+APP_DIR = File.join(IOS_DIR, "FarmManagementApp")
+CORE_DIR = File.join(IOS_DIR, "FarmManagementCore", "Sources", "FarmManagementCore")
+PROJECT_PATH = File.join(IOS_DIR, "FarmManagementApp.xcodeproj")
+
+FileUtils.rm_rf(PROJECT_PATH)
+
+project = Xcodeproj::Project.new(PROJECT_PATH)
+project.root_object.attributes["LastUpgradeCheck"] = "1600"
+
+app_target = project.new_target(:application, "FarmManagementApp", :ios, "16.0")
+core_target = project.new_target(:framework, "FarmManagementCore", :ios, "16.0")
+
+app_target.build_configurations.each do |config|
+  config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = "com.farmmanagement.ios"
+  config.build_settings["INFOPLIST_FILE"] = "FarmManagementApp/Config/Info.plist"
+  config.build_settings["SWIFT_VERSION"] = "5.0"
+  config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "16.0"
+  config.build_settings["CODE_SIGN_STYLE"] = "Automatic"
+  config.build_settings["TARGETED_DEVICE_FAMILY"] = "1"
+  config.build_settings["LD_RUNPATH_SEARCH_PATHS"] = ["$(inherited)", "@executable_path/Frameworks"]
+end
+
+core_target.build_configurations.each do |config|
+  config.build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = "com.farmmanagement.core"
+  config.build_settings["DEFINES_MODULE"] = "YES"
+  config.build_settings["MACH_O_TYPE"] = "mh_dylib"
+  config.build_settings["GENERATE_INFOPLIST_FILE"] = "YES"
+  config.build_settings["SWIFT_VERSION"] = "5.0"
+  config.build_settings["IPHONEOS_DEPLOYMENT_TARGET"] = "16.0"
+  config.build_settings["CODE_SIGN_STYLE"] = "Automatic"
+end
+
+app_group = project.main_group.find_subpath("FarmManagementApp", true)
+core_group = project.main_group.find_subpath("FarmManagementCore", true)
+
+Dir.glob(File.join(APP_DIR, "**/*.swift")).sort.each do |file|
+  relative = file.sub("#{IOS_DIR}/", "")
+  ref = app_group.find_file_by_path(relative) || app_group.new_file(relative)
+  app_target.source_build_phase.add_file_reference(ref, true)
+end
+
+plist_path = "FarmManagementApp/Config/Info.plist"
+app_group.find_file_by_path(plist_path) || app_group.new_file(plist_path)
+
+Dir.glob(File.join(CORE_DIR, "**/*.swift")).sort.each do |file|
+  relative = file.sub("#{IOS_DIR}/", "")
+  ref = core_group.find_file_by_path(relative) || core_group.new_file(relative)
+  core_target.source_build_phase.add_file_reference(ref, true)
+end
+
+app_target.add_dependency(core_target)
+framework_ref = core_target.product_reference
+app_target.frameworks_build_phase.add_file_reference(framework_ref)
+embed_phase = app_target.new_copy_files_build_phase("Embed Frameworks")
+embed_phase.symbol_dst_subfolder_spec = :frameworks
+embed_phase.add_file_reference(framework_ref)
+
+project.save
+puts "Generated #{PROJECT_PATH}"


### PR DESCRIPTION
## Summary
Introduces the native **iOS** client (`ios/`) as a read-oriented phase: SwiftUI + MVVM, token auth via Keychain, and `FarmManagementCore` for API models and networking.

## What’s included
- **App**: login, dashboard, farm list/detail, house detail, realtime monitoring (polling), farm house comparison.
- **Core**: `APIClient`, Codable models, services for farms/houses/monitoring; `ContractCheck` + JSON fixtures for API decoding smoke tests.
- **Tooling**: `scripts/generate_ios_xcodeproj.rb`, `ios/fastlane` contract step, `ios/.gitignore` (excludes Xcode/SwiftPM build output — no DerivedData or `.build` committed).

## How to verify
- From `ios/FarmManagementCore`: `swift run ContractCheck`
- Open `ios/FarmManagementApp.xcodeproj` in Xcode and build for Simulator

## Notes
- Configure API base URL in `ios/FarmManagementApp/Config/Info.plist` / `AppEnvironment` for your environment.

Made with [Cursor](https://cursor.com)