### PR TITLE
feat(frontend): operations UX — DOD comparison, URL state, house switching

### DIFF
--- a/frontend/src/components/farms/UnifiedFarmDashboard.tsx
+++ b/frontend/src/components/farms/UnifiedFarmDashboard.tsx
@@ -66,6 +66,7 @@ import { MonitoringDashboardData } from '../../types/monitoring';
 import IntegrationManagement from './IntegrationManagement';
 import { useProgram } from '../../contexts/ProgramContext';
 import { rotemApi } from '../../services/rotemApi';
+import { lastHouseStorageKey } from '../../utils/houseDetailUrl';
 // Removed logger import - using console instead
 
 interface Farm {
@@ -838,12 +839,64 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
         </Alert>
       )}
 
-      {/* Houses Section */}
+      {/* Operations shortcuts */}
       <Card sx={{ mb: 3 }}>
         <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Operations
+          </Typography>
+          <Box display="flex" flexWrap="wrap" gap={1}>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<CompareArrows />}
+              onClick={() => navigate(`/farms/${farm.id}/houses/comparison?view=operations`)}
+            >
+              Compare day-over-day
+            </Button>
+            {farm.houses && farm.houses.length > 0 && (
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={() => navigate(`/farms/${farm.id}/houses/${farm.houses[0].id}?tab=overview`)}
+              >
+                First house overview
+              </Button>
+            )}
+            {(() => {
+              try {
+                const id = sessionStorage.getItem(lastHouseStorageKey(farm.id));
+                if (id && farm.houses?.some((h) => String(h.id) === id)) {
+                  return (
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={() => navigate(`/farms/${farm.id}/houses/${id}?tab=overview`)}
+                    >
+                      Last viewed house
+                    </Button>
+                  );
+                }
+              } catch {
+                /* ignore */
+              }
+              return null;
+            })()}
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Accordion defaultExpanded sx={{ mb: 3 }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6">Houses ({farm.houses?.length || 0})</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+      {/* Houses Section */}
+      <Card variant="outlined" sx={{ mb: 0 }}>
+        <CardContent>
           <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-            <Typography variant="h6">
-              Houses ({farm.houses?.length || 0})
+            <Typography variant="subtitle1" fontWeight={600}>
+              Summary
             </Typography>
             <Box display="flex" gap={1}>
               {farm.houses && farm.houses.length > 1 && (
@@ -966,6 +1019,8 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
           </Grid>
         </CardContent>
       </Card>
+        </AccordionDetails>
+      </Accordion>
 
       {/* Workers Section */}
       <Card sx={{ mb: 3 }}>
@@ -1019,12 +1074,14 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
       {farm.integration_type === 'rotem' && (
         <>
           {/* Real-time Sensor Data */}
-          <Card>
+          <Accordion defaultExpanded sx={{ mb: 3 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6">Real-time Rotem sensor data</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ px: 0, pt: 0 }}>
+          <Card variant="outlined">
             <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-                <Typography variant="h6">
-                  Real-time Sensor Data
-                </Typography>
+              <Box display="flex" justifyContent="flex-end" alignItems="center" mb={2}>
                 <Box display="flex" gap={1}>
                   <Button
                     variant="outlined"
@@ -1241,6 +1298,8 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
               )}
             </CardContent>
           </Card>
+            </AccordionDetails>
+          </Accordion>
 
           {/* Monitoring Dashboard */}
           <Card>

--- a/frontend/src/components/houses/ComparisonDashboard.tsx
+++ b/frontend/src/components/houses/ComparisonDashboard.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Box,
   Card,
@@ -28,6 +28,7 @@ import {
   Link,
   Tabs,
   Tab,
+  TextField,
 } from '@mui/material';
 import {
   Refresh,
@@ -44,9 +45,22 @@ import {
   Water,
   Air,
   Restaurant,
+  LocalFireDepartment,
 } from '@mui/icons-material';
 import api from '../../services/api';
 import { useFarm } from '../../contexts/FarmContext';
+import monitoringApi from '../../services/monitoringApi';
+import { HouseMonitoringKpis } from '../../types/monitoring';
+
+const COMPARISON_VIEW_KEYS = ['consumption', 'climate', 'environment', 'operations'] as const;
+
+function todayIsoLocal(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
 
 interface HouseComparison {
   house_id: number;
@@ -95,6 +109,7 @@ type SortDirection = 'asc' | 'desc';
 const ComparisonDashboard: React.FC = () => {
   const { farmId } = useParams<{ farmId?: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { farms } = useFarm();
   const [houses, setHouses] = useState<HouseComparison[]>([]);
   const [loading, setLoading] = useState(true);
@@ -104,9 +119,63 @@ const ComparisonDashboard: React.FC = () => {
   const [farmFilter, setFarmFilter] = useState<number | 'all'>(farmId ? parseInt(farmId) : 'all');
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [favorites, setFavorites] = useState<Set<number>>(new Set());
-  const [activeTab, setActiveTab] = useState(0);
+  const [dodRefDate, setDodRefDate] = useState(todayIsoLocal);
+  const [opsKpis, setOpsKpis] = useState<Record<number, HouseMonitoringKpis | null>>({});
+  const [opsLoading, setOpsLoading] = useState(false);
+
+  const viewFromUrl = searchParams.get('view');
+  const activeTab = useMemo(() => {
+    const idx = viewFromUrl ? COMPARISON_VIEW_KEYS.indexOf(viewFromUrl as (typeof COMPARISON_VIEW_KEYS)[number]) : -1;
+    return idx >= 0 ? idx : 0;
+  }, [viewFromUrl]);
+
+  const setViewTab = useCallback(
+    (index: number) => {
+      const key = COMPARISON_VIEW_KEYS[index] ?? 'consumption';
+      setSearchParams(
+        (prev) => {
+          const n = new URLSearchParams(prev);
+          n.set('view', key);
+          return n;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
 
   const currentFarm = farmId ? farms.find(f => f.id === parseInt(farmId)) : null;
+
+  useEffect(() => {
+    if (activeTab !== 3 || houses.length === 0) {
+      setOpsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setOpsLoading(true);
+    (async () => {
+      const next: Record<number, HouseMonitoringKpis | null> = {};
+      await Promise.all(
+        houses.map(async (h) => {
+          try {
+            const k = await monitoringApi.getHouseMonitoringKpis(h.house_id, {
+              dodReferenceDate: dodRefDate,
+            });
+            next[h.house_id] = k;
+          } catch {
+            next[h.house_id] = null;
+          }
+        })
+      );
+      if (!cancelled) {
+        setOpsKpis(next);
+        setOpsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, houses, dodRefDate]);
 
   const loadComparisonData = async () => {
     try {
@@ -258,11 +327,22 @@ const ComparisonDashboard: React.FC = () => {
   };
 
   const handleHouseClick = (house: HouseComparison) => {
+    const qs = new URLSearchParams();
+    qs.set('tab', 'overview');
+    qs.set('dod', dodRefDate);
     if (farmId) {
-      navigate(`/farms/${farmId}/houses/${house.house_id}`);
+      navigate(`/farms/${farmId}/houses/${house.house_id}?${qs.toString()}`);
     } else {
-      navigate(`/farms/${house.farm_id}/houses/${house.house_id}`);
+      navigate(`/farms/${house.farm_id}/houses/${house.house_id}?${qs.toString()}`);
     }
+  };
+
+  const opsDeltaChipColor = (deltaPct: number | null | undefined): 'success' | 'warning' | 'error' | 'default' => {
+    if (deltaPct === null || deltaPct === undefined) return 'default';
+    const abs = Math.abs(deltaPct);
+    if (abs <= 10) return 'success';
+    if (abs <= 25) return 'warning';
+    return 'error';
   };
 
   if (loading && houses.length === 0) {
@@ -359,11 +439,30 @@ const ComparisonDashboard: React.FC = () => {
       )}
 
       {/* View Tabs */}
-      <Tabs value={activeTab} onChange={(_, val) => setActiveTab(val)} sx={{ mb: 2 }}>
+      <Tabs value={activeTab} onChange={(_, val) => setViewTab(val)} sx={{ mb: 2 }}>
         <Tab icon={<Water />} label="Consumption" iconPosition="start" />
         <Tab icon={<Thermostat />} label="Climate" iconPosition="start" />
         <Tab icon={<Air />} label="Environment" iconPosition="start" />
+        <Tab icon={<LocalFireDepartment />} label="Day-over-day" iconPosition="start" />
       </Tabs>
+
+      {activeTab === 3 && (
+        <Box display="flex" flexWrap="wrap" alignItems="center" gap={2} sx={{ mb: 2 }}>
+          <TextField
+            label="DOD reference date"
+            type="date"
+            size="small"
+            value={dodRefDate}
+            onChange={(e) => setDodRefDate(e.target.value)}
+            InputLabelProps={{ shrink: true }}
+            sx={{ minWidth: 200 }}
+          />
+          <Typography variant="body2" color="text.secondary">
+            Same calendar day vs prior day for all houses (water, feed). Heater shows trailing 24h from KPIs.
+          </Typography>
+          {opsLoading && <CircularProgress size={22} />}
+        </Box>
+      )}
 
       {/* Table */}
       <Card>
@@ -406,6 +505,15 @@ const ComparisonDashboard: React.FC = () => {
                         🌾 Feed
                       </Box>
                     </TableCell>
+                  </>
+                )}
+
+                {activeTab === 3 && (
+                  <>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>Water Δ%</TableCell>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>Feed Δ%</TableCell>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 90 }}>Heater 24h</TableCell>
+                    <TableCell sx={{ ...headerCellStyle, minWidth: 80 }}>DOD data</TableCell>
                   </>
                 )}
 
@@ -482,7 +590,7 @@ const ComparisonDashboard: React.FC = () => {
             <TableBody>
               {houses.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={15} align="center">
+                  <TableCell colSpan={20} align="center">
                     <Typography variant="body2" color="text.secondary" py={4}>
                       No houses found
                     </Typography>
@@ -540,6 +648,63 @@ const ComparisonDashboard: React.FC = () => {
                         </TableCell>
                       </>
                     )}
+
+                    {activeTab === 3 && (() => {
+                      const k = opsKpis[house.house_id];
+                      const w = k?.water_day_over_day?.delta_pct;
+                      const f = k?.feed_day_over_day?.delta_pct;
+                      const hh = k?.heater_runtime?.hours_24h;
+                      const dodOk = k?.data_quality?.enough_for_dod_delta;
+                      return (
+                        <>
+                          <TableCell sx={cellStyle}>
+                            {opsLoading ? (
+                              <Typography variant="caption">…</Typography>
+                            ) : (
+                              <Chip
+                                size="small"
+                                variant="outlined"
+                                color={opsDeltaChipColor(w)}
+                                label={
+                                  w != null && !Number.isNaN(w) ? `${w >= 0 ? '+' : ''}${w.toFixed(1)}%` : '—'
+                                }
+                              />
+                            )}
+                          </TableCell>
+                          <TableCell sx={cellStyle}>
+                            {opsLoading ? (
+                              <Typography variant="caption">…</Typography>
+                            ) : (
+                              <Chip
+                                size="small"
+                                variant="outlined"
+                                color={opsDeltaChipColor(f)}
+                                label={
+                                  f != null && !Number.isNaN(f) ? `${f >= 0 ? '+' : ''}${f.toFixed(1)}%` : '—'
+                                }
+                              />
+                            )}
+                          </TableCell>
+                          <TableCell sx={cellStyle}>
+                            <Typography variant="body2">
+                              {!opsLoading && k ? (hh != null ? `${hh.toFixed(1)} h` : '—') : opsLoading ? '…' : '—'}
+                            </Typography>
+                          </TableCell>
+                          <TableCell sx={cellStyle}>
+                            {!opsLoading && k ? (
+                              <Chip
+                                size="small"
+                                label={dodOk ? 'OK' : 'Thin'}
+                                color={dodOk ? 'success' : 'warning'}
+                                variant="outlined"
+                              />
+                            ) : (
+                              <Typography variant="caption">…</Typography>
+                            )}
+                          </TableCell>
+                        </>
+                      );
+                    })()}
 
                     <TableCell sx={cellStyle}>
                       <Chip 
@@ -639,6 +804,12 @@ const ComparisonDashboard: React.FC = () => {
       </Card>
 
       {/* Summary Cards */}
+      {activeTab === 3 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+          Row click opens that house on Overview with the same DOD reference date in the URL. Use the date picker
+          above to compare all houses for the same calendar day.
+        </Typography>
+      ) : (
       <Box display="flex" gap={2} mt={2} flexWrap="wrap">
         <Card sx={{ flex: 1, minWidth: 200 }}>
           <CardContent>
@@ -685,6 +856,7 @@ const ComparisonDashboard: React.FC = () => {
           </CardContent>
         </Card>
       </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/houses/HouseDetailPage.tsx
+++ b/frontend/src/components/houses/HouseDetailPage.tsx
@@ -1,21 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Box,
   Typography,
-  Card,
-  CardContent,
-  Grid,
   Chip,
   CircularProgress,
   Alert,
   Tabs,
   Tab,
-  Paper,
   IconButton,
-  Tooltip,
   Breadcrumbs,
   Link,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  SelectChangeEvent,
 } from '@mui/material';
 import {
   ArrowBack,
@@ -43,6 +43,12 @@ import HouseMortalityTab from './HouseMortalityTab';
 import HouseIssuesTab from './HouseIssuesTab';
 import HouseWaterHistoryTab from './HouseWaterHistoryTab';
 import { QuickIssueButton } from '../issues';
+import {
+  tabKeyToIndex,
+  indexToTabKey,
+  overviewStorageKey,
+  lastHouseStorageKey,
+} from '../../utils/houseDetailUrl';
 
 interface HouseDetails {
   house: any;
@@ -86,11 +92,80 @@ function TabPanel(props: TabPanelProps) {
 const HouseDetailPage: React.FC = () => {
   const { houseId, farmId } = useParams<{ houseId: string; farmId?: string }>();
   const navigate = useNavigate();
-  const { farms } = useFarm();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { farms, houses: farmContextHouses, fetchHouses } = useFarm();
   const [houseDetails, setHouseDetails] = useState<HouseDetails | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState(0);
+
+  const farmIdNum = farmId ? parseInt(farmId, 10) : null;
+  const tabKeyRaw = searchParams.get('tab') ?? 'overview';
+  const focusDateParam = searchParams.get('focusDate');
+
+  useEffect(() => {
+    if (farmIdNum) {
+      fetchHouses(farmIdNum);
+    }
+  }, [farmIdNum, fetchHouses]);
+
+  const farmHousesSorted = useMemo(() => {
+    if (!farmIdNum) return [];
+    return farmContextHouses
+      .filter((h) => h.farm_id === farmIdNum)
+      .sort((a, b) => a.house_number - b.house_number);
+  }, [farmContextHouses, farmIdNum]);
+
+  const dodParam = searchParams.get('dod');
+  const effectiveDod = useMemo(() => {
+    if (dodParam) return dodParam;
+    if (!farmIdNum) return null;
+    try {
+      const raw = sessionStorage.getItem(overviewStorageKey(farmIdNum));
+      if (!raw) return null;
+      const o = JSON.parse(raw) as { dod?: string };
+      return o.dod ?? null;
+    } catch {
+      return null;
+    }
+  }, [dodParam, farmIdNum, houseId]);
+
+  const setDodPersisted = useCallback(
+    (d: string | null) => {
+      if (farmIdNum) {
+        try {
+          sessionStorage.setItem(overviewStorageKey(farmIdNum), JSON.stringify({ dod: d }));
+        } catch {
+          /* ignore */
+        }
+      }
+      setSearchParams(
+        (prev) => {
+          const n = new URLSearchParams(prev);
+          if (d) n.set('dod', d);
+          else n.delete('dod');
+          return n;
+        },
+        { replace: true }
+      );
+    },
+    [farmIdNum, setSearchParams]
+  );
+
+  const navigateToWaterHistoryTab = useCallback(
+    (focusDate?: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const n = new URLSearchParams(prev);
+          n.set('tab', 'water-history');
+          if (focusDate) n.set('focusDate', focusDate);
+          else n.delete('focusDate');
+          return n;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
 
   // Get farm info
   const currentFarm = farmId ? farms.find(f => f.id === parseInt(farmId)) : null;
@@ -129,11 +204,28 @@ const HouseDetailPage: React.FC = () => {
     });
   }
 
+  const normalizedTabKey =
+    tabKeyRaw === 'water-history' && !isFarmIntegrated ? 'overview' : tabKeyRaw;
+  const activeTab = useMemo(
+    () => tabKeyToIndex(normalizedTabKey, Boolean(isFarmIntegrated)),
+    [normalizedTabKey, isFarmIntegrated]
+  );
+
   useEffect(() => {
     if (houseId) {
       loadHouseDetails();
     }
   }, [houseId]);
+
+  useEffect(() => {
+    if (farmIdNum && houseId) {
+      try {
+        sessionStorage.setItem(lastHouseStorageKey(farmIdNum), houseId);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [farmIdNum, houseId]);
 
   const loadHouseDetails = async () => {
     try {
@@ -149,8 +241,22 @@ const HouseDetailPage: React.FC = () => {
     }
   };
 
-  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
-    setActiveTab(newValue);
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
+    const key = indexToTabKey(newValue, Boolean(isFarmIntegrated));
+    setSearchParams(
+      (prev) => {
+        const n = new URLSearchParams(prev);
+        n.set('tab', key);
+        return n;
+      },
+      { replace: true }
+    );
+  };
+
+  const handleHouseSwitcherChange = (event: SelectChangeEvent<number>) => {
+    const nextId = event.target.value as number;
+    if (!farmId || String(nextId) === houseId) return;
+    navigate(`/farms/${farmId}/houses/${nextId}?${searchParams.toString()}`);
   };
 
   if (loading) {
@@ -247,6 +353,23 @@ const HouseDetailPage: React.FC = () => {
                   : 'default'
               }
             />
+            {farmId && farmHousesSorted.length > 1 && (
+              <FormControl size="small" sx={{ minWidth: 200 }}>
+                <InputLabel id="house-switch-label">House</InputLabel>
+                <Select
+                  labelId="house-switch-label"
+                  label="House"
+                  value={parseInt(houseId!, 10)}
+                  onChange={handleHouseSwitcherChange}
+                >
+                  {farmHousesSorted.map((h) => (
+                    <MenuItem key={h.id} value={h.id}>
+                      House {h.house_number}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
           </Box>
           <Box display="flex" gap={1}>
             {(farmId || houseFarmId) && (
@@ -344,6 +467,9 @@ const HouseDetailPage: React.FC = () => {
           alarms={houseDetails.alarms}
           stats={houseDetails.stats}
           onRefresh={loadHouseDetails}
+          dodReferenceDate={effectiveDod}
+          onDodReferenceDateChange={setDodPersisted}
+          onNavigateToWaterHistory={isFarmIntegrated ? navigateToWaterHistoryTab : undefined}
         />
       </TabPanel>
       <TabPanel value={activeTab} index={1}>
@@ -379,7 +505,11 @@ const HouseDetailPage: React.FC = () => {
       </TabPanel>
       {isFarmIntegrated && (
         <TabPanel value={activeTab} index={8}>
-          <HouseWaterHistoryTab houseId={houseId!} house={house} />
+          <HouseWaterHistoryTab
+            houseId={houseId!}
+            house={house}
+            focusDate={focusDateParam}
+          />
         </TabPanel>
       )}
 

--- a/frontend/src/components/houses/HouseMonitoringCharts.tsx
+++ b/frontend/src/components/houses/HouseMonitoringCharts.tsx
@@ -30,17 +30,25 @@ import { HouseMonitoringSummary } from '../../types/monitoring';
 
 interface HouseMonitoringChartsProps {
   houseId: number;
+  /** When set (e.g. from Overview trend dialog), emphasize consumption and use a longer default window. */
+  highlightMetric?: 'water' | 'feed';
 }
 
-const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }) => {
+const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId, highlightMetric }) => {
   const [history, setHistory] = useState<HouseMonitoringSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [period, setPeriod] = useState<number>(24); // hours
+  const [period, setPeriod] = useState<number>(highlightMetric ? 168 : 24); // hours
 
   useEffect(() => {
     fetchHistory();
   }, [houseId, period]);
+
+  useEffect(() => {
+    if (highlightMetric) {
+      setPeriod(168);
+    }
+  }, [highlightMetric]);
 
   const fetchHistory = async () => {
     setLoading(true);
@@ -101,10 +109,23 @@ const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }
     feed: snapshot.feed_consumption,
   }));
 
+  const emphasisSx = highlightMetric
+    ? { border: 2, borderColor: 'primary.main', borderRadius: 1 }
+    : undefined;
+
   return (
     <Box>
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-        <Typography variant="h6">Historical Data</Typography>
+        <Box display="flex" alignItems="baseline" gap={1} flexWrap="wrap">
+          <Typography variant="h6" component="span">
+            Historical Data
+          </Typography>
+          {highlightMetric ? (
+            <Typography variant="body2" color="primary" component="span">
+              (highlight: {highlightMetric})
+            </Typography>
+          ) : null}
+        </Box>
         <FormControl size="small" sx={{ minWidth: 150 }}>
           <Select value={period} onChange={handlePeriodChange}>
             <MenuItem value={6}>Last 6 hours</MenuItem>
@@ -118,6 +139,7 @@ const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }
 
       <Grid container spacing={2}>
         {/* Temperature Chart */}
+        {!highlightMetric && (
         <Grid item xs={12} md={6}>
           <Card>
             <CardContent>
@@ -156,8 +178,10 @@ const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }
             </CardContent>
           </Card>
         </Grid>
+        )}
 
         {/* Humidity & Pressure Chart */}
+        {!highlightMetric && (
         <Grid item xs={12} md={6}>
           <Card>
             <CardContent>
@@ -186,8 +210,10 @@ const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }
             </CardContent>
           </Card>
         </Grid>
+        )}
 
         {/* Ventilation Chart */}
+        {!highlightMetric && (
         <Grid item xs={12} md={6}>
           <Card>
             <CardContent>
@@ -213,10 +239,11 @@ const HouseMonitoringCharts: React.FC<HouseMonitoringChartsProps> = ({ houseId }
             </CardContent>
           </Card>
         </Grid>
+        )}
 
         {/* Consumption Chart */}
-        <Grid item xs={12} md={6}>
-          <Card>
+        <Grid item xs={12} md={highlightMetric ? 12 : 6}>
+          <Card sx={emphasisSx}>
             <CardContent>
               <Typography variant="subtitle1" gutterBottom>
                 Consumption

--- a/frontend/src/components/houses/HouseOverviewTab.tsx
+++ b/frontend/src/components/houses/HouseOverviewTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import {
   Box,
   Grid,
@@ -19,6 +19,10 @@ import {
   Button,
   CircularProgress,
   Alert,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import {
   Refresh,
@@ -35,6 +39,7 @@ import {
 } from '@mui/icons-material';
 import monitoringApi from '../../services/monitoringApi';
 import { HouseMonitoringKpis } from '../../types/monitoring';
+import HouseMonitoringCharts from './HouseMonitoringCharts';
 
 /** Command 43 heater history daily row (API `heater_history.daily`). */
 interface HeaterHistoryDailyRow {
@@ -61,6 +66,11 @@ interface HouseOverviewTabProps {
   alarms: any[];
   stats: any;
   onRefresh: () => void;
+  /** Day-over-day reference date (YYYY-MM-DD), controlled from URL / storage */
+  dodReferenceDate: string | null;
+  onDodReferenceDateChange: (date: string | null) => void;
+  /** Navigate to Water History tab; optional calendar day to highlight */
+  onNavigateToWaterHistory?: (focusDate?: string | null) => void;
 }
 
 const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
@@ -69,6 +79,9 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
   alarms,
   stats,
   onRefresh,
+  dodReferenceDate,
+  onDodReferenceDateChange,
+  onNavigateToWaterHistory,
 }) => {
   const [kpis, setKpis] = useState<HouseMonitoringKpis | null>(null);
   const [kpiLoading, setKpiLoading] = useState(false);
@@ -76,11 +89,14 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
   const [heaterRotemLoading, setHeaterRotemLoading] = useState(false);
   const [heaterCacheLoading, setHeaterCacheLoading] = useState(false);
   const [heaterError, setHeaterError] = useState<string | null>(null);
-  const [dodReferenceDate, setDodReferenceDate] = useState<string | null>(null);
   const [selectedHeaterGrowthDay, setSelectedHeaterGrowthDay] = useState<number | null>(null);
+  const [heaterDetailOpen, setHeaterDetailOpen] = useState(false);
+  const [trendOpen, setTrendOpen] = useState(false);
+  const [trendMetric, setTrendMetric] = useState<'water' | 'feed'>('water');
+  const dodRef = useRef(dodReferenceDate);
+  dodRef.current = dodReferenceDate;
 
   useEffect(() => {
-    setDodReferenceDate(null);
     setSelectedHeaterGrowthDay(null);
     setHeaterHistory(null);
     setHeaterError(null);
@@ -105,18 +121,41 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
     loadKpis();
   }, [house?.id, monitoring?.timestamp, dodReferenceDate]);
 
-  const applyHeaterHistoryPayload = (hist: Record<string, unknown>) => {
-    setHeaterHistory(hist);
-    const daily = hist?.daily as HeaterHistoryDailyRow[] | undefined;
-    if (daily && daily.length > 0) {
-      const last = daily[daily.length - 1];
-      setSelectedHeaterGrowthDay(last.growth_day);
-      setDodReferenceDate(typeof last.date === 'string' ? last.date : null);
-    } else {
-      setSelectedHeaterGrowthDay(null);
-      setDodReferenceDate(null);
-    }
-  };
+  const applyHeaterHistoryPayload = useCallback(
+    (hist: Record<string, unknown>, alignDod: string | null | undefined) => {
+      setHeaterHistory(hist);
+      const daily = hist?.daily as HeaterHistoryDailyRow[] | undefined;
+      if (daily && daily.length > 0) {
+        const match =
+          alignDod != null && alignDod !== ''
+            ? daily.find((r) => r.date === alignDod)
+            : undefined;
+        const pick = match || daily[daily.length - 1];
+        setSelectedHeaterGrowthDay(pick.growth_day);
+      } else {
+        setSelectedHeaterGrowthDay(null);
+      }
+    },
+    []
+  );
+
+  /** Auto-load cached heater history when house changes (cheap path; Rotem fetch stays manual). */
+  useEffect(() => {
+    if (!house?.id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await monitoringApi.getHouseHeaterHistory(house.id);
+        if (cancelled) return;
+        applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>, dodRef.current);
+      } catch {
+        /* ignore — user can load manually */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [house?.id, applyHeaterHistoryPayload]);
 
   const loadHeaterHistoryCached = async () => {
     if (!house?.id) return;
@@ -124,7 +163,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
       setHeaterCacheLoading(true);
       setHeaterError(null);
       const data = await monitoringApi.getHouseHeaterHistory(house.id);
-      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>);
+      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>, dodRef.current);
     } catch (error) {
       console.error('Failed to load cached heater history:', error);
       setHeaterError('Could not load saved heater history.');
@@ -139,7 +178,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
       setHeaterRotemLoading(true);
       setHeaterError(null);
       const data = await monitoringApi.refreshHouseHeaterHistory(house.id);
-      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>);
+      applyHeaterHistoryPayload(data.heater_history as Record<string, unknown>, dodRef.current);
     } catch (error: any) {
       const msg =
         error?.response?.data?.error ||
@@ -217,6 +256,13 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
     selectedHeaterGrowthDay != null
       ? heaterDaily.find((r) => r.growth_day === selectedHeaterGrowthDay)
       : undefined;
+
+  useEffect(() => {
+    const daily = heaterHistory?.daily as HeaterHistoryDailyRow[] | undefined;
+    if (!daily?.length || dodReferenceDate == null || dodReferenceDate === '') return;
+    const row = daily.find((r) => r.date === dodReferenceDate);
+    if (row) setSelectedHeaterGrowthDay(row.growth_day);
+  }, [dodReferenceDate, heaterHistory]);
 
   if (!monitoring) {
     return (
@@ -307,8 +353,8 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                 </Box>
               </Box>
               <Typography variant="body2" color="text.secondary" mb={1}>
-                Not loaded with the page. Use the buttons above so the house overview stays fast. Select a row to
-                align water/feed day-over-day with that calendar day (when a date is present).
+                Cached history loads automatically when you open Overview; use &quot;Fetch from Rotem&quot; for the
+                latest from the controller. Select a row to align water/feed day-over-day with that calendar day.
               </Typography>
               {heaterError && (
                 <Alert severity="error" sx={{ mb: 1 }} onClose={() => setHeaterError(null)}>
@@ -360,7 +406,7 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                               selected={selectedHeaterGrowthDay === row.growth_day}
                               onClick={() => {
                                 setSelectedHeaterGrowthDay(row.growth_day);
-                                setDodReferenceDate(row.date ?? null);
+                                onDodReferenceDateChange(row.date ?? null);
                               }}
                               sx={{
                                 cursor: 'pointer',
@@ -393,11 +439,16 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                         borderColor: 'divider',
                       }}
                     >
-                      <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                        Selected — Day {selectedHeaterRow.growth_day}
-                        {selectedHeaterRow.date ? ` · ${selectedHeaterRow.date}` : ''} — per device
-                      </Typography>
-                      <Box display="flex" flexWrap="wrap" gap={0.5}>
+                      <Box display="flex" flexWrap="wrap" alignItems="center" justifyContent="space-between" gap={1}>
+                        <Typography variant="subtitle2" color="text.secondary">
+                          Selected — Day {selectedHeaterRow.growth_day}
+                          {selectedHeaterRow.date ? ` · ${selectedHeaterRow.date}` : ''} — per device
+                        </Typography>
+                        <Button size="small" variant="outlined" onClick={() => setHeaterDetailOpen(true)}>
+                          Open day details
+                        </Button>
+                      </Box>
+                      <Box display="flex" flexWrap="wrap" gap={0.5} mt={1}>
                         {Object.entries(selectedHeaterRow.per_device || {}).map(([device, value]) => (
                           <Chip
                             key={device}
@@ -420,18 +471,45 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
         </Grid>
 
         <Grid item xs={12} md={4}>
-          <Card>
+          <Card
+            variant="outlined"
+            sx={{
+              cursor: onNavigateToWaterHistory ? 'pointer' : 'default',
+              transition: 'box-shadow 0.2s',
+              '&:hover': onNavigateToWaterHistory ? { boxShadow: 2 } : {},
+            }}
+            onClick={() => {
+              if (onNavigateToWaterHistory) {
+                onNavigateToWaterHistory(kpis?.day_over_day_context?.reference_date ?? null);
+              }
+            }}
+          >
             <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+              <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={1}>
                 <Box display="flex" alignItems="center" gap={1}>
                   <TrendingUp color="info" />
                   <Typography variant="subtitle2">Water Day-over-Day</Typography>
                 </Box>
-                <Chip
-                  size="small"
-                  color={getTrendColor(kpis?.water_day_over_day?.delta_pct)}
-                  label={formatDelta(kpis?.water_day_over_day?.delta, kpis?.water_day_over_day?.delta_pct, 'L')}
-                />
+                <Box display="flex" flexDirection="column" alignItems="flex-end" gap={0.5}>
+                  <Chip
+                    size="small"
+                    color={getTrendColor(kpis?.water_day_over_day?.delta_pct)}
+                    label={formatDelta(kpis?.water_day_over_day?.delta, kpis?.water_day_over_day?.delta_pct, 'L')}
+                  />
+                  <Tooltip title="Short-term trend (snapshots)">
+                    <Button
+                      size="small"
+                      variant="text"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setTrendMetric('water');
+                        setTrendOpen(true);
+                      }}
+                    >
+                      View trend
+                    </Button>
+                  </Tooltip>
+                </Box>
               </Box>
               <Typography variant="caption" color="text.secondary" component="div">
                 {formatDodCaption(
@@ -440,14 +518,26 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                   'L'
                 )}
               </Typography>
+              {onNavigateToWaterHistory && (
+                <Typography variant="caption" color="primary" sx={{ mt: 0.5, display: 'block' }}>
+                  Click card to open Water History
+                </Typography>
+              )}
             </CardContent>
           </Card>
         </Grid>
 
         <Grid item xs={12} md={4}>
-          <Card>
+          <Card
+            variant="outlined"
+            sx={{ cursor: 'pointer', transition: 'box-shadow 0.2s', '&:hover': { boxShadow: 2 } }}
+            onClick={() => {
+              setTrendMetric('feed');
+              setTrendOpen(true);
+            }}
+          >
             <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+              <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={1}>
                 <Box display="flex" alignItems="center" gap={1}>
                   <TrendingFlat color="secondary" />
                   <Typography variant="subtitle2">Feed Day-over-Day</Typography>
@@ -464,6 +554,9 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
                   kpis?.feed_day_over_day?.previous,
                   'lb'
                 )}
+              </Typography>
+              <Typography variant="caption" color="primary" sx={{ mt: 0.5, display: 'block' }}>
+                Click card for consumption trend
               </Typography>
             </CardContent>
           </Card>
@@ -751,6 +844,46 @@ const HouseOverviewTab: React.FC<HouseOverviewTabProps> = ({
           </Card>
         </Grid>
       </Grid>
+
+      <Dialog open={heaterDetailOpen} onClose={() => setHeaterDetailOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Heater runtime — Day {selectedHeaterRow?.growth_day ?? '—'}
+          {selectedHeaterRow?.date ? ` · ${selectedHeaterRow.date}` : ''}
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" color="text.secondary" gutterBottom>
+            Per-device hours for the selected day
+          </Typography>
+          <Box display="flex" flexWrap="wrap" gap={0.5}>
+            {selectedHeaterRow &&
+              Object.entries(selectedHeaterRow.per_device || {}).map(([device, value]) => (
+                <Chip
+                  key={device}
+                  size="medium"
+                  variant="outlined"
+                  label={`${device.replace(/_/g, ' ')}: ${value.hours} h`}
+                />
+              ))}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setHeaterDetailOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={trendOpen} onClose={() => setTrendOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>
+          {trendMetric === 'water' ? 'Water' : 'Feed'} — recent snapshots
+        </DialogTitle>
+        <DialogContent>
+          {house?.id ? (
+            <HouseMonitoringCharts houseId={house.id} highlightMetric={trendMetric} />
+          ) : null}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setTrendOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/frontend/src/components/houses/HouseWaterHistoryTab.tsx
+++ b/frontend/src/components/houses/HouseWaterHistoryTab.tsx
@@ -41,9 +41,11 @@ interface HouseWaterHistoryTabProps {
     };
     farm_id?: number;
   };
+  /** From house detail URL (?focusDate=YYYY-MM-DD) when navigating from Overview DOD */
+  focusDate?: string | null;
 }
 
-export const HouseWaterHistoryTab: React.FC<HouseWaterHistoryTabProps> = ({ houseId, house }) => {
+export const HouseWaterHistoryTab: React.FC<HouseWaterHistoryTabProps> = ({ houseId, house, focusDate }) => {
   const { farms } = useFarm();
   const [waterHistory, setWaterHistory] = useState<any>(null);
   const [loading, setLoading] = useState(true);
@@ -324,6 +326,11 @@ export const HouseWaterHistoryTab: React.FC<HouseWaterHistoryTabProps> = ({ hous
 
   return (
     <Box>
+      {focusDate ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Opened from Overview with reference date <strong>{focusDate}</strong> (compare with charts below).
+        </Alert>
+      ) : null}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
         <Typography variant="h5">Water Consumption History - House {house.house_number}</Typography>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>

--- a/frontend/src/utils/houseDetailUrl.ts
+++ b/frontend/src/utils/houseDetailUrl.ts
@@ -1,0 +1,37 @@
+/** URL tab keys for house detail (order matches Tab panels when Water History is shown). */
+export const HOUSE_TAB_KEYS = [
+  'overview',
+  'devices',
+  'flock',
+  'tasks',
+  'messages',
+  'mortality',
+  'issues',
+  'menu',
+  'water-history',
+] as const;
+
+export type HouseTabKey = (typeof HOUSE_TAB_KEYS)[number];
+
+export function tabKeyToIndex(key: string, hasWaterHistoryTab: boolean): number {
+  const keys = hasWaterHistoryTab
+    ? [...HOUSE_TAB_KEYS]
+    : HOUSE_TAB_KEYS.filter((k) => k !== 'water-history');
+  const idx = keys.indexOf(key as HouseTabKey);
+  return idx >= 0 ? idx : 0;
+}
+
+export function indexToTabKey(index: number, hasWaterHistoryTab: boolean): string {
+  const keys = hasWaterHistoryTab
+    ? [...HOUSE_TAB_KEYS]
+    : HOUSE_TAB_KEYS.filter((k) => k !== 'water-history');
+  return keys[index] ?? 'overview';
+}
+
+export function overviewStorageKey(farmId: number): string {
+  return `farm:${farmId}:overview`;
+}
+
+export function lastHouseStorageKey(farmId: number): string {
+  return `farm:${farmId}:lastHouseId`;
+}


### PR DESCRIPTION
## Summary
Implements the frontend UX plan for farm/house operations: day-over-day comparison, drill-downs, and fast house switching with preserved context.

## Changes
- **House detail (`HouseDetailPage`)**: Query params `tab`, `dod`, `focusDate`; DOD persisted via URL and `sessionStorage`; in-header **house selector** keeps the same query when switching houses.
- **Overview (`HouseOverviewTab`)**: Controlled DOD; auto-load cached heater history; clickable water/feed cards (Water History + trend dialogs); heater day detail dialog.
- **Comparison (`ComparisonDashboard`)**: **Day-over-day** tab with parallel `getHouseMonitoringKpis` calls, reference date picker, row navigation to Overview with matching `dod`.
- **Farm dashboard (`UnifiedFarmDashboard`)**: Operations shortcuts (compare DOD, first/last house); accordions for houses grid and Rotem real-time sensors.
- **Utilities**: `frontend/src/utils/houseDetailUrl.ts` for tab keys and storage keys.
- **Charts**: `HouseMonitoringCharts` supports `highlightMetric` for trend dialog.

## How to test
1. Open a farm → use Operations shortcuts and accordions.
2. **Compare Houses** → **Day-over-day** tab → change date → click a house row → confirm Overview opens with `dod` in URL.
3. House detail → switch house via dropdown → confirm tab and `dod` persist.
4. Overview → water DOD card → Water History; feed card → trend dialog.

## Notes
- N parallel KPI requests on the DOD comparison tab; a batch API could be a follow-up if needed.

Made with [Cursor](https://cursor.com)