### PR TITLE
Fix intermittent partial/missing data in farm monitoring pipeline

### DIFF
--- a/backend/chicken_management/settings.py
+++ b/backend/chicken_management/settings.py
@@ -329,13 +329,15 @@ CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = TIME_ZONE
+CELERY_TASK_ACKS_LATE = True
+CELERY_TASK_REJECT_ON_WORKER_LOST = True
 
 # Celery Beat schedule
 CELERY_BEAT_SCHEDULE = {
-    # Legacy Rotem scraper tasks (for existing farms)
-    'scrape-rotem-data-every-5-minutes': {
-        'task': 'rotem_scraper.tasks.scrape_rotem_data',
-        'schedule': 300.0,  # Every 5 minutes (300 seconds)
+    # Unified monitoring sync (replaces scrape_rotem_data + sync_farm_data)
+    'sync-all-farms-monitoring-every-5-minutes': {
+        'task': 'rotem_scraper.tasks.sync_all_farms_monitoring',
+        'schedule': 300.0,  # Every 5 minutes
     },
     'analyze-data-every-hour': {
         'task': 'rotem_scraper.tasks.analyze_data',
@@ -350,11 +352,7 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': 604800.0,  # Every week (604800 seconds)
     },
     
-    # New integration tasks
-    'sync-integrated-farms-every-5-minutes': {
-        'task': 'integrations.tasks.sync_farm_data',
-        'schedule': 300.0,  # Every 5 minutes (300 seconds)
-    },
+    # sync_farm_data removed from beat; replaced by sync_all_farms_monitoring above
     'test-integration-connections-every-hour': {
         'task': 'integrations.tasks.test_integration_connections',
         'schedule': 3600.0,  # Every hour (3600 seconds)

--- a/backend/houses/migrations/0011_farmmonitoringcache_house_statuses.py
+++ b/backend/houses/migrations/0011_farmmonitoringcache_house_statuses.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('houses', '0010_farmmonitoringcache_housemonitoringcache_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='farmmonitoringcache',
+            name='house_statuses',
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/backend/houses/models.py
+++ b/backend/houses/models.py
@@ -234,6 +234,7 @@ class FarmMonitoringCache(models.Model):
     dashboard_payload = models.JSONField(default=dict)
     comparison_payload = models.JSONField(default=dict)
     houses_payload = models.JSONField(default=dict)
+    house_statuses = models.JSONField(default=dict, blank=True)
     source_timestamp = models.DateTimeField(null=True, blank=True)
     fetched_at = models.DateTimeField(auto_now=True, db_index=True)
     refresh_state = models.CharField(max_length=16, choices=REFRESH_STATE_CHOICES, default="idle")

--- a/backend/houses/services/monitoring_cache_service.py
+++ b/backend/houses/services/monitoring_cache_service.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+from django.db import transaction
 from django.utils import timezone
 import logging
 
@@ -13,7 +14,24 @@ from rotem_scraper.scraper import RotemScraper
 
 
 MAX_STALE_SECONDS = 600
+CIRCUIT_OPEN_THRESHOLD = 5
 logger = logging.getLogger(__name__)
+
+# Module-level Redis client (lazy-initialised, None if Redis unavailable)
+_redis_client = None
+
+
+def _get_redis():
+    global _redis_client
+    if _redis_client is None:
+        try:
+            import redis as redis_lib
+            from django.conf import settings
+            _redis_client = redis_lib.from_url(settings.CELERY_BROKER_URL, socket_connect_timeout=2)
+        except Exception as exc:
+            logger.warning("redis_unavailable lock_disabled err=%s", exc)
+            _redis_client = False  # sentinel: don't retry
+    return _redis_client if _redis_client else None
 
 
 def safe_float(value):
@@ -91,6 +109,8 @@ def build_meta(
     source_timestamp: Optional[datetime],
     refresh_state: str,
     stale_seconds: int = MAX_STALE_SECONDS,
+    house_statuses: Optional[Dict] = None,
+    circuit_open: bool = False,
 ):
     now = timezone.now()
     source = source_timestamp or fetched_at
@@ -98,14 +118,18 @@ def build_meta(
     if source:
         age_seconds = max(int((now - source).total_seconds()), 0)
     is_stale = age_seconds is None or age_seconds > stale_seconds
-    return {
+    meta = {
         "source_timestamp": source.isoformat() if source else None,
         "fetched_at": fetched_at.isoformat() if fetched_at else None,
         "age_seconds": age_seconds,
         "is_stale": is_stale,
         "refresh_state": refresh_state,
         "can_refresh_now": True,
+        "circuit_open": circuit_open,
     }
+    if house_statuses is not None:
+        meta["house_statuses"] = house_statuses
+    return meta
 
 
 def wrap_cached_response(data: Any, meta: Dict[str, Any]):
@@ -291,30 +315,67 @@ def _build_house_heater_payload(house: House, scraper: RotemScraper):
     return {"heater_history": {"daily": daily}}
 
 
-def _upsert_house_payloads(house: House, scraper: RotemScraper, site_payload: dict):
-    live = extract_live_house(site_payload, house.house_number)
-    if not live:
-        return
-    source_ts = parse_source_timestamp(site_payload) or timezone.now()
+def _build_house_cache_payloads(house: House, scraper: RotemScraper, live: dict, source_ts: datetime) -> dict:
+    """Build all per-house cache payloads in memory (does NOT write to DB)."""
     history_payload = _build_house_history(house, scraper)
     kpis_payload = _build_house_kpis(house, scraper)
     heater_payload = _build_house_heater_payload(house, scraper)
-    HouseMonitoringCache.objects.update_or_create(
-        house=house,
-        defaults={
-            "latest_payload": live,
-            "history_payload": history_payload,
-            "kpis_payload": kpis_payload,
-            "heater_payload": heater_payload,
-            "source_timestamp": source_ts,
-            "refresh_state": "fresh",
-            "last_error": "",
-        },
-    )
+    return {
+        "latest_payload": live,
+        "history_payload": history_payload,
+        "kpis_payload": kpis_payload,
+        "heater_payload": heater_payload,
+        "source_timestamp": source_ts,
+        "refresh_state": "fresh",
+        "last_error": "",
+    }
+
+
+def _is_circuit_open(farm: Farm) -> bool:
+    try:
+        from integrations.models import IntegrationHealth
+        health = IntegrationHealth.objects.filter(farm=farm, integration_type="rotem").first()
+        return health is not None and health.consecutive_failures >= CIRCUIT_OPEN_THRESHOLD
+    except Exception:
+        return False
 
 
 def upsert_farm_monitoring_cache(farm: Farm) -> UpsertResult:
     started = timezone.now()
+
+    # --- Distributed lock (prevents concurrent scrapes for same farm) ---
+    lock = None
+    r = _get_redis()
+    if r:
+        try:
+            lock = r.lock(f"scrape_lock:farm:{farm.id}", timeout=240, blocking_timeout=5)
+            if not lock.acquire(blocking=True):
+                logger.info("scrape_lock_skipped farm=%s reason=lock_not_acquired", farm.id)
+                return UpsertResult(status="skipped", message="lock_not_acquired")
+        except Exception as exc:
+            logger.warning("scrape_lock_error farm=%s err=%s proceeding_without_lock", farm.id, exc)
+            lock = None
+
+    try:
+        return _upsert_farm_monitoring_cache_inner(farm, started)
+    finally:
+        if lock:
+            try:
+                lock.release()
+            except Exception:
+                pass
+
+
+def _upsert_farm_monitoring_cache_inner(farm: Farm, started: datetime) -> UpsertResult:
+    # --- Circuit breaker ---
+    if _is_circuit_open(farm):
+        logger.warning("circuit_open farm=%s serving_cache", farm.id)
+        FarmMonitoringCache.objects.filter(farm=farm).update(
+            refresh_state="failed", last_error="circuit_open"
+        )
+        return UpsertResult(status="circuit_open", message="circuit_open")
+
+    # --- Login ---
     scraper = _farm_scraper(farm)
     if not scraper:
         FarmMonitoringCache.objects.update_or_create(
@@ -331,65 +392,153 @@ def upsert_farm_monitoring_cache(farm: Farm) -> UpsertResult:
         )
         return UpsertResult(status="error", message="empty_site_controllers")
 
-    response_obj = site_payload.get("reponseObj", {}) if isinstance(site_payload, dict) else {}
     houses = list(House.objects.filter(farm=farm, is_active=True).order_by("house_number"))
+
+    # --- Phase 1: Collect all house live data in memory ---
+    house_live: Dict[int, Optional[dict]] = {}  # house.id -> live dict or None
+    for house in houses:
+        house_live[house.id] = extract_live_house(site_payload, house.house_number)
+
+    failed_house_numbers = {
+        h.house_number for h in houses if house_live[h.id] is None
+    }
+
+    # --- Phase 2: Per-house retry for partial failures ---
+    if 0 < len(failed_house_numbers) <= 4:
+        logger.warning(
+            "scrape_partial_failure farm=%s failed_houses=%s retrying",
+            farm.id, sorted(failed_house_numbers),
+        )
+        retry_scraper = _farm_scraper(farm)
+        if retry_scraper:
+            retry_site = retry_scraper.get_site_controllers_info() or {}
+            for house in houses:
+                if house.house_number in failed_house_numbers:
+                    live = extract_live_house(retry_site, house.house_number)
+                    if live:
+                        house_live[house.id] = live
+                        failed_house_numbers.discard(house.house_number)
+            if failed_house_numbers:
+                logger.warning(
+                    "retry_still_failing farm=%s houses=%s",
+                    farm.id, sorted(failed_house_numbers),
+                )
+
+    # Load existing house_statuses to carry forward stale timestamps
+    existing_cache = FarmMonitoringCache.objects.filter(farm=farm).first()
+    prev_house_statuses: dict = (existing_cache.house_statuses or {}) if existing_cache else {}
+
+    # --- Build house_statuses and in-memory payloads ---
+    source_ts = parse_source_timestamp(site_payload) or timezone.now()
+    response_obj = site_payload.get("reponseObj", {}) if isinstance(site_payload, dict) else {}
+
     houses_all_payload = []
     dashboard_houses = []
     comparison_houses = []
+    house_cache_payloads: Dict[int, dict] = {}  # house.id -> HouseMonitoringCache defaults
+    house_statuses: Dict[str, dict] = {}
     alerts_summary = {"total_active": 0, "critical": 0, "warning": 0, "normal": 0}
     connection_summary = {"connected": 0, "disconnected": 0}
-    houses_upserted = 0
 
     for house in houses:
-        live = extract_live_house(site_payload, house.house_number)
-        if not live:
+        live = house_live[house.id]
+        hn = str(house.house_number)
+
+        if live is None:
+            # Mark as failed or stale (carry previous timestamp if available)
+            prev = prev_house_statuses.get(hn, {})
+            prev_ts = prev.get("source_timestamp")
+            prev_status = prev.get("status")
+            house_statuses[hn] = {
+                "status": "stale" if prev_status == "ok" else "failed",
+                "source_timestamp": prev_ts,
+                "error_msg": "no_live_data",
+            }
+            # Still include in dashboard/houses payloads using previous data if available
+            prev_latest = None
+            if existing_cache and isinstance(existing_cache.houses_payload, dict):
+                prev_houses = existing_cache.houses_payload.get("houses", [])
+                for ph in prev_houses:
+                    if isinstance(ph, dict) and ph.get("house_number") == house.house_number:
+                        prev_latest = ph
+                        break
+            if prev_latest:
+                houses_all_payload.append(prev_latest)
+                dashboard_houses.append({
+                    "house_id": house.id,
+                    "house_number": house.house_number,
+                    "current_day": house.age_days,
+                    "status": house.status,
+                    "active_alarms_count": 0,
+                    "timestamp": prev_latest.get("timestamp"),
+                    "source_timestamp": prev_latest.get("source_timestamp"),
+                    "average_temperature": prev_latest.get("average_temperature"),
+                    "humidity": prev_latest.get("humidity"),
+                    "static_pressure": prev_latest.get("static_pressure"),
+                    "airflow_percentage": prev_latest.get("airflow_percentage"),
+                    "water_consumption": prev_latest.get("water_consumption"),
+                    "feed_consumption": prev_latest.get("feed_consumption"),
+                    "is_connected": prev_latest.get("is_connected", False),
+                    "alarm_status": prev_latest.get("alarm_status", "normal"),
+                    "data_status": "stale",
+                })
             continue
-        houses_all_payload.append(
-            {
-                "house_id": house.id,
-                "house_number": house.house_number,
-                "timestamp": live.get("timestamp"),
-                "source_timestamp": live.get("source_timestamp"),
-                "average_temperature": live.get("average_temperature"),
-                "outside_temperature": None,
-                "humidity": live.get("humidity"),
-                "static_pressure": live.get("static_pressure"),
-                "target_temperature": None,
-                "ventilation_level": live.get("airflow_percentage"),
-                "growth_day": house.age_days,
-                "bird_count": None,
-                "livability": None,
-                "water_consumption": live.get("water_consumption"),
-                "feed_consumption": live.get("feed_consumption"),
-                "airflow_cfm": None,
-                "airflow_percentage": live.get("airflow_percentage"),
-                "connection_status": "connected" if live.get("is_connected") else "disconnected",
-                "alarm_status": live.get("alarm_status") or "normal",
-                "has_alarms": False,
-                "is_connected": bool(live.get("is_connected")),
-            }
-        )
+
+        # House has fresh live data
+        house_statuses[hn] = {
+            "status": "ok",
+            "source_timestamp": live.get("source_timestamp"),
+            "error_msg": None,
+        }
+
         alarm_status = live.get("alarm_status") or "normal"
-        dashboard_houses.append(
-            {
-                "house_id": house.id,
-                "house_number": house.house_number,
-                "current_day": house.age_days,
-                "status": house.status,
-                "active_alarms_count": 0,
-                "timestamp": live.get("timestamp"),
-                "source_timestamp": live.get("source_timestamp"),
-                "average_temperature": live.get("average_temperature"),
-                "humidity": live.get("humidity"),
-                "static_pressure": live.get("static_pressure"),
-                "airflow_percentage": live.get("airflow_percentage"),
-                "water_consumption": live.get("water_consumption"),
-                "feed_consumption": live.get("feed_consumption"),
-                "is_connected": bool(live.get("is_connected")),
-                "alarm_status": alarm_status,
-            }
-        )
-        if bool(live.get("is_connected")):
+        is_connected = bool(live.get("is_connected"))
+
+        houses_all_payload.append({
+            "house_id": house.id,
+            "house_number": house.house_number,
+            "timestamp": live.get("timestamp"),
+            "source_timestamp": live.get("source_timestamp"),
+            "average_temperature": live.get("average_temperature"),
+            "outside_temperature": None,
+            "humidity": live.get("humidity"),
+            "static_pressure": live.get("static_pressure"),
+            "target_temperature": None,
+            "ventilation_level": live.get("airflow_percentage"),
+            "growth_day": house.age_days,
+            "bird_count": None,
+            "livability": None,
+            "water_consumption": live.get("water_consumption"),
+            "feed_consumption": live.get("feed_consumption"),
+            "airflow_cfm": None,
+            "airflow_percentage": live.get("airflow_percentage"),
+            "connection_status": "connected" if is_connected else "disconnected",
+            "alarm_status": alarm_status,
+            "has_alarms": False,
+            "is_connected": is_connected,
+            "data_status": "ok",
+        })
+
+        dashboard_houses.append({
+            "house_id": house.id,
+            "house_number": house.house_number,
+            "current_day": house.age_days,
+            "status": house.status,
+            "active_alarms_count": 0,
+            "timestamp": live.get("timestamp"),
+            "source_timestamp": live.get("source_timestamp"),
+            "average_temperature": live.get("average_temperature"),
+            "humidity": live.get("humidity"),
+            "static_pressure": live.get("static_pressure"),
+            "airflow_percentage": live.get("airflow_percentage"),
+            "water_consumption": live.get("water_consumption"),
+            "feed_consumption": live.get("feed_consumption"),
+            "is_connected": is_connected,
+            "alarm_status": alarm_status,
+            "data_status": "ok",
+        })
+
+        if is_connected:
             connection_summary["connected"] += 1
         else:
             connection_summary["disconnected"] += 1
@@ -400,92 +549,118 @@ def upsert_farm_monitoring_cache(farm: Farm) -> UpsertResult:
         else:
             alerts_summary["normal"] += 1
 
-        comparison_houses.append(
-            {
-                "house_id": house.id,
-                "house_number": house.house_number,
-                "farm_id": house.farm.id,
-                "farm_name": house.farm.name,
-                "current_day": house.age_days,
-                "age_days": house.age_days,
-                "current_age_days": house.current_age_days,
-                "is_integrated": house.is_integrated,
-                "status": house.status,
-                "is_full_house": house.age_days is not None and house.age_days >= 0,
-                "last_update_time": live.get("source_timestamp") or timezone.now().isoformat(),
-                "average_temperature": live.get("average_temperature"),
-                "outside_temperature": safe_float(
-                    extract_comparison_item(response_obj, "Outside_Temperature", house.house_number)
-                ),
-                "tunnel_temperature": safe_float(
-                    extract_comparison_item(response_obj, "Tunnel_Temperature", house.house_number)
-                ),
-                "target_temperature": safe_float(
-                    extract_comparison_item(response_obj, "Set_Temperature", house.house_number)
-                ),
-                "static_pressure": live.get("static_pressure"),
-                "inside_humidity": live.get("humidity"),
-                "ventilation_mode": extract_comparison_item(response_obj, "Vent_Mode", house.house_number),
-                "ventilation_level": safe_float(
-                    extract_comparison_item(response_obj, "Vent_Level", house.house_number)
-                ),
-                "airflow_cfm": safe_float(
-                    str(extract_comparison_item(response_obj, "Current_Level_CFM", house.house_number) or "").replace(",", "")
-                ),
-                "airflow_percentage": live.get("airflow_percentage"),
-                "water_consumption": safe_float(
-                    extract_comparison_item(response_obj, "Water_Daily", house.house_number)
-                )
-                or live.get("water_consumption"),
-                "feed_consumption": safe_float(
-                    extract_comparison_item(response_obj, "Feed_Daily", house.house_number)
-                )
-                or live.get("feed_consumption"),
-                "bird_count": safe_float(
-                    extract_comparison_item(response_obj, "Current_Birds_Count_In_House", house.house_number)
-                ),
-                "is_connected": bool(live.get("is_connected")),
-                "has_alarms": False,
-                "alarm_status": live.get("alarm_status") or "normal",
-                "active_alarms_count": None,
+        comparison_houses.append({
+            "house_id": house.id,
+            "house_number": house.house_number,
+            "farm_id": house.farm.id,
+            "farm_name": house.farm.name,
+            "current_day": house.age_days,
+            "age_days": house.age_days,
+            "current_age_days": house.current_age_days,
+            "is_integrated": house.is_integrated,
+            "status": house.status,
+            "is_full_house": house.age_days is not None and house.age_days >= 0,
+            "last_update_time": live.get("source_timestamp") or timezone.now().isoformat(),
+            "average_temperature": live.get("average_temperature"),
+            "outside_temperature": safe_float(
+                extract_comparison_item(response_obj, "Outside_Temperature", house.house_number)
+            ),
+            "tunnel_temperature": safe_float(
+                extract_comparison_item(response_obj, "Tunnel_Temperature", house.house_number)
+            ),
+            "target_temperature": safe_float(
+                extract_comparison_item(response_obj, "Set_Temperature", house.house_number)
+            ),
+            "static_pressure": live.get("static_pressure"),
+            "inside_humidity": live.get("humidity"),
+            "ventilation_mode": extract_comparison_item(response_obj, "Vent_Mode", house.house_number),
+            "ventilation_level": safe_float(
+                extract_comparison_item(response_obj, "Vent_Level", house.house_number)
+            ),
+            "airflow_cfm": safe_float(
+                str(extract_comparison_item(response_obj, "Current_Level_CFM", house.house_number) or "").replace(",", "")
+            ),
+            "airflow_percentage": live.get("airflow_percentage"),
+            "water_consumption": safe_float(
+                extract_comparison_item(response_obj, "Water_Daily", house.house_number)
+            ) or live.get("water_consumption"),
+            "feed_consumption": safe_float(
+                extract_comparison_item(response_obj, "Feed_Daily", house.house_number)
+            ) or live.get("feed_consumption"),
+            "bird_count": safe_float(
+                extract_comparison_item(response_obj, "Current_Birds_Count_In_House", house.house_number)
+            ),
+            "is_connected": is_connected,
+            "has_alarms": False,
+            "alarm_status": alarm_status,
+            "active_alarms_count": None,
+        })
+
+        # Build per-house cache payloads in memory (expensive Rotem calls, outside the DB transaction)
+        try:
+            house_cache_payloads[house.id] = _build_house_cache_payloads(house, scraper, live, source_ts)
+        except Exception as exc:
+            logger.warning("house_payload_build_failed farm=%s house=%s err=%s", farm.id, house.house_number, exc)
+            house_cache_payloads[house.id] = {
+                "latest_payload": live,
+                "history_payload": {},
+                "kpis_payload": {},
+                "heater_payload": {},
+                "source_timestamp": source_ts,
+                "refresh_state": "fresh",
+                "last_error": str(exc),
             }
-        )
-        _upsert_house_payloads(house, scraper, site_payload)
-        houses_upserted += 1
 
     alerts_summary["total_active"] = alerts_summary["critical"] + alerts_summary["warning"]
-    source_ts = parse_source_timestamp(site_payload) or timezone.now()
-    FarmMonitoringCache.objects.update_or_create(
-        farm=farm,
-        defaults={
-            "dashboard_payload": {
-                "farm_id": farm.id,
-                "farm_name": farm.name,
-                "total_houses": len(houses),
-                "houses": dashboard_houses,
-                "alerts_summary": alerts_summary,
-                "connection_summary": connection_summary,
-            },
-            "comparison_payload": {"count": len(comparison_houses), "houses": comparison_houses},
-            "houses_payload": {
-                "farm_id": farm.id,
-                "farm_name": farm.name,
-                "houses_count": len(houses_all_payload),
-                "houses": houses_all_payload,
-            },
-            "source_timestamp": source_ts,
-            "refresh_state": "fresh",
-            "last_error": "",
+    houses_processed = sum(1 for h in houses if house_live[h.id] is not None)
+
+    # --- Phase 3: Atomic commit ---
+    farm_cache_defaults = {
+        "dashboard_payload": {
+            "farm_id": farm.id,
+            "farm_name": farm.name,
+            "total_houses": len(houses),
+            "houses": dashboard_houses,
+            "alerts_summary": alerts_summary,
+            "connection_summary": connection_summary,
         },
-    )
+        "comparison_payload": {"count": len(comparison_houses), "houses": comparison_houses},
+        "houses_payload": {
+            "farm_id": farm.id,
+            "farm_name": farm.name,
+            "houses_count": len(houses_all_payload),
+            "houses": houses_all_payload,
+        },
+        "house_statuses": house_statuses,
+        "source_timestamp": source_ts,
+        "refresh_state": "fresh",
+        "last_error": "",
+    }
+
+    with transaction.atomic():
+        # Lock the farm cache row to prevent concurrent writers
+        locked_cache = FarmMonitoringCache.objects.select_for_update().filter(farm=farm).first()
+        if locked_cache:
+            for k, v in farm_cache_defaults.items():
+                setattr(locked_cache, k, v)
+            locked_cache.save()
+        else:
+            FarmMonitoringCache.objects.create(farm=farm, **farm_cache_defaults)
+
+        # Write all per-house caches atomically
+        for house in houses:
+            if house.id in house_cache_payloads:
+                HouseMonitoringCache.objects.update_or_create(
+                    house=house,
+                    defaults=house_cache_payloads[house.id],
+                )
+
     elapsed_ms = int((timezone.now() - started).total_seconds() * 1000)
     logger.info(
-        "monitoring cache upsert farm=%s status=success houses=%s elapsed_ms=%s",
-        farm.id,
-        houses_upserted,
-        elapsed_ms,
+        "monitoring_cache_upsert farm=%s status=success houses_ok=%s houses_failed=%s elapsed_ms=%s",
+        farm.id, houses_processed, len(failed_house_numbers), elapsed_ms,
     )
-    return UpsertResult(status="success", farms_processed=1, houses_processed=houses_upserted)
+    return UpsertResult(status="success", farms_processed=1, houses_processed=houses_processed)
 
 
 def upsert_monitoring_cache_for_all_farms() -> UpsertResult:
@@ -510,11 +685,7 @@ def upsert_monitoring_cache_for_all_farms() -> UpsertResult:
     )
     elapsed_ms = int((timezone.now() - started).total_seconds() * 1000)
     logger.info(
-        "monitoring cache batch status=%s farms_processed=%s houses_processed=%s elapsed_ms=%s failures=%s",
-        result.status,
-        result.farms_processed,
-        result.houses_processed,
-        elapsed_ms,
-        len(failures),
+        "monitoring_cache_batch status=%s farms_processed=%s houses_processed=%s elapsed_ms=%s failures=%s",
+        result.status, result.farms_processed, result.houses_processed, elapsed_ms, len(failures),
     )
     return result

--- a/backend/houses/urls.py
+++ b/backend/houses/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('farms/<int:farm_id>/houses/monitoring/dashboard/', views.farm_houses_monitoring_dashboard, name='farm-houses-monitoring-dashboard'),
     path('farms/<int:farm_id>/houses/monitoring/snapshot/', views.farm_houses_monitoring_snapshot, name='farm-houses-monitoring-snapshot'),
     path('farms/<int:farm_id>/houses/monitoring/refresh/', views.farm_monitoring_refresh, name='farm-monitoring-refresh'),
+    path('farms/<int:farm_id>/ios/snapshot/', views.farm_ios_snapshot, name='farm-ios-snapshot'),
     
     # Comparison endpoint
     path('houses/comparison/', views.houses_comparison, name='houses-comparison'),

--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -1954,3 +1954,123 @@ def sync_flock_from_rotem(request, house_id):
         },
         status=status.HTTP_200_OK,
     )
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def farm_ios_snapshot(request, farm_id):
+    """
+    Unified iOS snapshot: all monitoring data the iOS app needs in one
+    cache-consistent response. All fields come from the same scrape cycle,
+    eliminating the inconsistency caused by merging three separate endpoints.
+
+    Returns farm-level metadata, per-house freshness statuses, and a complete
+    houses array with every sensor field.
+    """
+    farm = get_object_or_404(_scoped_farms_queryset(request), id=farm_id)
+
+    cache = FarmMonitoringCache.objects.filter(farm=farm).first()
+
+    now = timezone.now()
+    circuit_open = bool(
+        cache and cache.last_error == "circuit_open" and cache.refresh_state == "failed"
+    )
+
+    # Build per-house list from cache
+    houses_data = []
+    if cache and isinstance(cache.houses_payload, dict):
+        for h in cache.houses_payload.get("houses", []):
+            if isinstance(h, dict):
+                houses_data.append(h)
+
+    # For any active house missing from cache, fall back to latest DB snapshot
+    if cache:
+        cached_house_numbers = {h.get("house_number") for h in houses_data if isinstance(h, dict)}
+        db_houses = House.objects.filter(farm=farm, is_active=True).exclude(
+            house_number__in=cached_house_numbers
+        )
+        for house in db_houses:
+            snap = (
+                HouseMonitoringSnapshot.objects
+                .filter(house=house)
+                .order_by("-timestamp")
+                .first()
+            )
+            if snap:
+                houses_data.append({
+                    "house_id": house.id,
+                    "house_number": house.house_number,
+                    "timestamp": snap.timestamp.isoformat(),
+                    "source_timestamp": snap.timestamp.isoformat(),
+                    "average_temperature": float(snap.average_temperature) if snap.average_temperature is not None else None,
+                    "humidity": float(snap.humidity) if snap.humidity is not None else None,
+                    "static_pressure": float(snap.static_pressure) if snap.static_pressure is not None else None,
+                    "airflow_percentage": float(snap.ventilation_level) if snap.ventilation_level is not None else None,
+                    "water_consumption": float(snap.water_consumption) if snap.water_consumption is not None else None,
+                    "feed_consumption": float(snap.feed_consumption) if snap.feed_consumption is not None else None,
+                    "current_day": house.age_days,
+                    "status": house.status,
+                    "is_connected": snap.connection_status == 1,
+                    "alarm_status": snap.alarm_status or "normal",
+                    "active_alarms_count": 0,
+                    "data_status": "db_fallback",
+                })
+
+    source_ts = cache.source_timestamp if cache else None
+    fetched_at = cache.fetched_at if cache else now
+    refresh_state = cache.refresh_state if cache else "idle"
+    house_statuses = (cache.house_statuses or {}) if cache else {}
+
+    meta = build_meta(
+        fetched_at=fetched_at,
+        source_timestamp=source_ts,
+        refresh_state=refresh_state,
+        stale_seconds=MAX_STALE_SECONDS,
+        house_statuses=house_statuses,
+        circuit_open=circuit_open,
+    )
+
+    dashboard = (cache.dashboard_payload or {}) if cache else {}
+    alerts_summary = dashboard.get("alerts_summary", {
+        "total_active": 0, "critical": 0, "warning": 0, "normal": 0,
+    })
+    connection_summary = dashboard.get("connection_summary", {
+        "connected": 0, "disconnected": 0,
+    })
+
+    # Per-house alert details (for iOS alarm mapping)
+    alerts_by_house = {}
+    try:
+        active_alerts = WaterConsumptionAlert.objects.filter(
+            farm=farm,
+            is_resolved=False,
+        ).select_related("house")
+        for alert in active_alerts:
+            house_id = alert.house_id
+            if house_id not in alerts_by_house:
+                alerts_by_house[str(house_id)] = {
+                    "active_count": 0,
+                    "highest_severity": "low",
+                    "latest_message": None,
+                }
+            entry = alerts_by_house[str(house_id)]
+            entry["active_count"] += 1
+            severity_rank = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+            if severity_rank.get(alert.severity, 0) > severity_rank.get(entry["highest_severity"], 0):
+                entry["highest_severity"] = alert.severity
+            if entry["latest_message"] is None:
+                entry["latest_message"] = getattr(alert, "message", None) or f"Water alert ({alert.severity})"
+    except Exception:
+        pass
+
+    data = {
+        "farm_id": farm.id,
+        "farm_name": farm.name,
+        "total_houses": House.objects.filter(farm=farm, is_active=True).count(),
+        "houses": sorted(houses_data, key=lambda h: h.get("house_number", 0) if isinstance(h, dict) else 0),
+        "alerts_summary": alerts_summary,
+        "alerts_by_house": alerts_by_house,
+        "connection_summary": connection_summary,
+    }
+
+    return Response(wrap_cached_response(data, meta))

--- a/backend/rotem_scraper/tasks.py
+++ b/backend/rotem_scraper/tasks.py
@@ -295,14 +295,13 @@ def calculate_daily_flock_performance(self):
     """
     try:
         from rotem_scraper.flock_performance_calculator import calculate_all_flock_performance
-        from django.utils import timezone
 
         logger.info("Starting daily flock performance calculation task")
 
         results = calculate_all_flock_performance()
 
         summary = (
-            f"✅ Daily flock performance calculation complete. "
+            f"Daily flock performance calculation complete. "
             f"Success: {results['success']}, Failed: {results['failed']}"
         )
 
@@ -316,5 +315,83 @@ def calculate_daily_flock_performance(self):
 
     except Exception as exc:
         logger.error(f"Daily flock performance calculation failed: {str(exc)}", exc_info=True)
-        # Retry in 5 minutes if failed
         raise self.retry(exc=exc, countdown=300)
+
+
+@shared_task(bind=True, max_retries=2, acks_late=True, task_reject_on_worker_lost=True)
+def sync_farm_monitoring(self, farm_id: int):
+    """
+    Single canonical task: full scrape + atomic cache update for one farm.
+    Replaces the overlapping scrape_rotem_data + sync_farm_data tasks.
+
+    Includes Redis lock (in the service layer), circuit breaker, per-house
+    retry on partial failure, and atomic DB commit.
+    """
+    from farms.models import Farm
+    from houses.services.monitoring_cache_service import upsert_farm_monitoring_cache
+
+    try:
+        farm = Farm.objects.get(id=farm_id)
+    except Farm.DoesNotExist:
+        logger.error("sync_farm_monitoring: farm_id=%s not found", farm_id)
+        return
+
+    try:
+        result = upsert_farm_monitoring_cache(farm)
+    except Exception as exc:
+        logger.error("sync_farm_monitoring: farm=%s unexpected_error=%s", farm_id, exc, exc_info=True)
+        _update_integration_health(farm, "error")
+        raise self.retry(exc=exc, countdown=60)
+
+    _update_integration_health(farm, result.status)
+    logger.info("sync_farm_monitoring farm=%s status=%s houses=%s", farm_id, result.status, result.houses_processed)
+    return {"status": result.status, "houses_processed": result.houses_processed}
+
+
+@shared_task
+def sync_all_farms_monitoring():
+    """
+    Fan-out orchestrator: dispatches a sync_farm_monitoring task for each active
+    Rotem-integrated farm. This single beat-schedule entry replaces the two
+    overlapping 5-minute tasks (scrape_rotem_data + sync_farm_data).
+    """
+    from farms.models import Farm
+
+    farm_ids = list(
+        Farm.objects.filter(
+            is_active=True,
+            has_system_integration=True,
+            integration_type="rotem",
+        ).values_list("id", flat=True)
+    )
+    for farm_id in farm_ids:
+        sync_farm_monitoring.apply_async(args=[farm_id])
+    logger.info("sync_all_farms_monitoring dispatched farm_count=%s", len(farm_ids))
+    return {"dispatched": len(farm_ids)}
+
+
+def _update_integration_health(farm, result_status: str):
+    """Update IntegrationHealth consecutive_failures counter based on task result."""
+    try:
+        from integrations.models import IntegrationHealth
+        health, _ = IntegrationHealth.objects.get_or_create(
+            farm=farm,
+            integration_type="rotem",
+            defaults={"is_healthy": True, "consecutive_failures": 0},
+        )
+        if result_status == "success":
+            health.consecutive_failures = 0
+            health.is_healthy = True
+            health.last_successful_sync = timezone.now()
+        elif result_status == "skipped":
+            pass  # lock contention — not a failure
+        elif result_status != "circuit_open":
+            health.consecutive_failures = (health.consecutive_failures or 0) + 1
+            health.is_healthy = False
+        health.last_attempted_sync = timezone.now()
+        health.save(update_fields=[
+            "consecutive_failures", "is_healthy",
+            "last_attempted_sync", "last_successful_sync",
+        ])
+    except Exception as exc:
+        logger.warning("_update_integration_health failed farm=%s err=%s", getattr(farm, "id", "?"), exc)

--- a/mobile/ios/RotemFarm-iOS/RotemFarm/Services/APIClient.swift
+++ b/mobile/ios/RotemFarm-iOS/RotemFarm/Services/APIClient.swift
@@ -199,6 +199,39 @@ struct APIFarmMonitoringDashboardResult {
     let freshness: APIFreshnessMeta?
 }
 
+/// Unified iOS snapshot — all sensor fields from one cache-consistent response.
+struct APIFarmIOSSnapshotHouse {
+    let houseID: Int
+    let houseNumber: Int
+    let currentDay: Int?
+    let averageTemperature: Double?
+    let humidity: Double?
+    let staticPressure: Double?
+    let airflowPercentage: Double?
+    let waterConsumption: Double?
+    let feedConsumption: Double?
+    let isConnected: Bool
+    let alarmStatus: String
+    let dataStatus: String  // "ok" | "stale" | "failed" | "db_fallback"
+}
+
+struct APIFarmIOSSnapshotAlert {
+    let houseID: Int
+    let activeCount: Int
+    let highestSeverity: String
+    let latestMessage: String?
+}
+
+struct APIFarmIOSSnapshotResult {
+    let farmID: Int
+    let farmName: String
+    let houses: [APIFarmIOSSnapshotHouse]
+    let alertsByHouseID: [Int: APIFarmIOSSnapshotAlert]
+    let alertsSummaryTotalActive: Int
+    let freshness: APIFreshnessMeta?
+    let circuitOpen: Bool
+}
+
 struct APITask {
     let id: Int
     let houseID: Int?
@@ -492,6 +525,79 @@ actor APIClient {
             houses: mappedHouses,
             alertsByHouseID: alertsByHouseID,
             freshness: envelope.meta
+        )
+    }
+
+    /// Unified iOS snapshot: all sensor data for a farm in one cache-consistent response.
+    /// Replaces the three parallel fetchFarmMonitoringDashboard / fetchFarmHouseSensorData /
+    /// fetchFarmMonitoringSnapshot calls and eliminates cross-cycle data inconsistency.
+    func fetchFarmIOSSnapshot(farmID: Int) async throws -> APIFarmIOSSnapshotResult {
+        let data = try await request(
+            path: "/api/farms/\(farmID)/ios/snapshot/",
+            method: "GET",
+            payload: nil,
+            requiresAuth: true
+        )
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw APIClientError.decoding
+        }
+        let envelope = decodeEnvelope(root)
+        let payload = envelope.payload
+        let freshness = envelope.meta
+        let rawMeta = root["meta"] as? [String: Any]
+
+        let farmID = payload["farm_id"] as? Int ?? farmID
+        let farmName = payload["farm_name"] as? String ?? ""
+        let circuitOpen = (rawMeta?["circuit_open"] as? Bool) ?? false
+
+        let rawHouses = payload["houses"] as? [[String: Any]] ?? []
+        let mappedHouses: [APIFarmIOSSnapshotHouse] = rawHouses.compactMap { h in
+            guard let houseID = h["house_id"] as? Int else { return nil }
+            func dbl(_ key: String) -> Double? {
+                if let v = h[key] as? Double { return v }
+                if let v = h[key] as? Int { return Double(v) }
+                return nil
+            }
+            return APIFarmIOSSnapshotHouse(
+                houseID: houseID,
+                houseNumber: (h["house_number"] as? Int) ?? houseID,
+                currentDay: h["current_day"] as? Int,
+                averageTemperature: dbl("average_temperature"),
+                humidity: dbl("humidity"),
+                staticPressure: dbl("static_pressure"),
+                airflowPercentage: dbl("airflow_percentage"),
+                waterConsumption: dbl("water_consumption"),
+                feedConsumption: dbl("feed_consumption"),
+                isConnected: (h["is_connected"] as? Bool) ?? false,
+                alarmStatus: (h["alarm_status"] as? String) ?? "normal",
+                dataStatus: (h["data_status"] as? String) ?? "ok"
+            )
+        }
+
+        var alertsByHouseID: [Int: APIFarmIOSSnapshotAlert] = [:]
+        if let rawAlerts = payload["alerts_by_house"] as? [String: [String: Any]] {
+            for (houseIDStr, alertData) in rawAlerts {
+                guard let houseID = Int(houseIDStr) else { continue }
+                alertsByHouseID[houseID] = APIFarmIOSSnapshotAlert(
+                    houseID: houseID,
+                    activeCount: (alertData["active_count"] as? Int) ?? 0,
+                    highestSeverity: (alertData["highest_severity"] as? String) ?? "low",
+                    latestMessage: alertData["latest_message"] as? String
+                )
+            }
+        }
+
+        let alertsSummary = payload["alerts_summary"] as? [String: Any] ?? [:]
+        let alertsTotal = (alertsSummary["total_active"] as? Int) ?? 0
+
+        return APIFarmIOSSnapshotResult(
+            farmID: farmID,
+            farmName: farmName,
+            houses: mappedHouses,
+            alertsByHouseID: alertsByHouseID,
+            alertsSummaryTotalActive: alertsTotal,
+            freshness: freshness,
+            circuitOpen: circuitOpen
         )
     }
 

--- a/mobile/ios/RotemFarm-iOS/RotemFarm/Services/MockDataStore.swift
+++ b/mobile/ios/RotemFarm-iOS/RotemFarm/Services/MockDataStore.swift
@@ -346,14 +346,11 @@ final class MockDataStore {
             log("reloadSelectedFarmData() farmBackendID=\(selectedFarmBackendID)")
             let client = apiClient
             let apiHouses = try await apiClient.fetchHouses(farmID: selectedFarmBackendID)
-            async let dashboardFetch = try? await apiClient.fetchFarmMonitoringDashboard(farmID: selectedFarmBackendID)
-            async let sensorFetch = try? await apiClient.fetchFarmHouseSensorData(farmID: selectedFarmBackendID)
-            async let snapshotFetch = try? await apiClient.fetchFarmMonitoringSnapshot(farmID: selectedFarmBackendID)
-            let dashboardCards = (await dashboardFetch)?.houses ?? []
-            let dashboardByHouseID = Dictionary(uniqueKeysWithValues: dashboardCards.map { ($0.houseID, $0) })
-            let webParitySensorByHouseNumber = await sensorFetch ?? [:]
-            let farmSnapshot = await snapshotFetch
-            let snapshotByHouseID = Dictionary(uniqueKeysWithValues: (farmSnapshot?.houses ?? []).map { ($0.houseID, $0) })
+            // Unified single-request snapshot — eliminates 3-endpoint merge inconsistency
+            let iosSnapshot = try? await apiClient.fetchFarmIOSSnapshot(farmID: selectedFarmBackendID)
+            let iosHouseByID = Dictionary(
+                uniqueKeysWithValues: (iosSnapshot?.houses ?? []).map { ($0.houseID, $0) }
+            )
 
             let activeHouses = apiHouses.filter(\.isActive)
             let snapshotHouses = houses
@@ -362,34 +359,24 @@ final class MockDataStore {
             for apiHouse in activeHouses {
                 let houseID = Self.stableUUID(prefix: "house", intID: apiHouse.id)
                 let fallbackSnapshot = snapshotHouses.first(where: { $0.backendId == apiHouse.id })?.snapshot
-                let dashboardCard = dashboardByHouseID[apiHouse.id]
-                let webParityMonitoring = webParitySensorByHouseNumber[apiHouse.houseNumber]
-                let aggregated = snapshotByHouseID[apiHouse.id]
-                let resolvedTemp = aggregated?.averageTemperature
-                    ?? webParityMonitoring?.averageTemperature
-                    ?? dashboardCard?.averageTemperature
+                // Single consistent source — all fields from the same scrape cycle
+                let iosHouseData = iosHouseByID[apiHouse.id]
+                let resolvedTemp = iosHouseData?.averageTemperature
                     ?? fallbackSnapshot?.tempC
                     ?? .nan
-                let resolvedHumidity = aggregated?.humidity
-                    ?? webParityMonitoring?.humidity
+                let resolvedHumidity = iosHouseData?.humidity
                     ?? fallbackSnapshot?.humidity
                     ?? .nan
-                let resolvedStatic = aggregated?.staticPressure
-                    ?? webParityMonitoring?.staticPressure
+                let resolvedStatic = iosHouseData?.staticPressure
                     ?? fallbackSnapshot?.staticPressurePa
                     ?? .nan
-                let resolvedAirflow = aggregated?.airflowPercentage
-                    ?? webParityMonitoring?.airflowPercentage
+                let resolvedAirflow = iosHouseData?.airflowPercentage
                     ?? fallbackSnapshot?.airflowPct
                     ?? .nan
-                let resolvedWater = aggregated?.waterConsumption
-                    ?? webParityMonitoring?.waterConsumption
-                    ?? dashboardCard?.waterConsumption
+                let resolvedWater = iosHouseData?.waterConsumption
                     ?? fallbackSnapshot?.waterLphr
                     ?? .nan
-                let resolvedFeed = aggregated?.feedConsumption
-                    ?? webParityMonitoring?.feedConsumption
-                    ?? dashboardCard?.feedConsumption
+                let resolvedFeed = iosHouseData?.feedConsumption
                     ?? fallbackSnapshot?.feedLbs
                     ?? .nan
                 let snapshot = HouseSnapshot(
@@ -419,13 +406,13 @@ final class MockDataStore {
                         name: "House \(apiHouse.houseNumber)",
                         type: .tunnel,
                         birdCount: 0,
-                        flockDay: aggregated?.currentDay ?? apiHouse.currentDay,
+                        flockDay: iosHouseData?.currentDay ?? apiHouse.currentDay,
                         state: state,
                         pillText: state == .ok ? "All OK" : (state == .warning ? "Check conditions" : "Needs attention"),
                         snapshot: snapshot
                     )
                 )
-                if let alert = farmSnapshot?.alertsByHouseID[apiHouse.id], alert.activeCount > 0 {
+                if let alert = iosSnapshot?.alertsByHouseID[apiHouse.id], alert.activeCount > 0 {
                     mappedAlarms.append(
                         Alarm(
                             id: Self.stableUUID(prefix: "snapshot-alert", intID: apiHouse.id),
@@ -486,6 +473,9 @@ final class MockDataStore {
             houseHeaterRealtimeByHouseId = heaterRealtimeByHouse
             houseRealtimeLoadedIds = loadedRealtimeHouseIDs
             alarms = mappedAlarms.sorted { $0.occurredAt > $1.occurredAt }
+            if let freshness = iosSnapshot?.freshness {
+                monitoringFreshnessByFarmId[selectedFarm.id] = freshness
+            }
             if let idx = farms.firstIndex(where: { $0.id == currentFarmId }) {
                 farms[idx].houseIds = houses.map(\.id)
                 farms[idx].alertSummary = alarms.isEmpty ? "No alerts" : "\(alarms.count) alerts"
@@ -867,12 +857,23 @@ final class MockDataStore {
 
     func fetchFarmMonitoringDashboard(farmBackendID: Int) async -> [APIFarmHouseMonitoringCard] {
         do {
-            let result = try await apiClient.fetchFarmMonitoringDashboard(farmID: farmBackendID)
+            let snapshot = try await apiClient.fetchFarmIOSSnapshot(farmID: farmBackendID)
             if let farmUUID = farms.first(where: { $0.backendId == farmBackendID })?.id,
-               let freshness = result.freshness {
+               let freshness = snapshot.freshness {
                 monitoringFreshnessByFarmId[farmUUID] = freshness
             }
-            return result.houses
+            return snapshot.houses.map { h in
+                APIFarmHouseMonitoringCard(
+                    houseID: h.houseID,
+                    houseNumber: h.houseNumber,
+                    averageTemperature: h.averageTemperature,
+                    waterConsumption: h.waterConsumption,
+                    feedConsumption: h.feedConsumption,
+                    growthDay: h.currentDay,
+                    houseCurrentDay: h.currentDay,
+                    activeAlarmsCount: snapshot.alertsByHouseID[h.houseID]?.activeCount ?? 0
+                )
+            }
         } catch {
             lastError = error.localizedDescription
             return []
@@ -978,20 +979,13 @@ final class MockDataStore {
                 let fallbackCount = farm.activeHousesFromApi
                 group.addTask {
                     do {
-                        let result = try await client.fetchFarmMonitoringDashboard(farmID: bid)
-                        let days = result.houses.compactMap { card -> Int? in
-                            if let g = card.growthDay { return g }
-                            return card.houseCurrentDay
-                        }
-                        let avg: Int? = {
-                            guard !days.isEmpty else { return nil }
-                            return days.reduce(0, +) / days.count
-                        }()
-                        let count = result.totalHouses > 0 ? result.totalHouses : result.houses.count
+                        let snapshot = try await client.fetchFarmIOSSnapshot(farmID: bid)
+                        let days = snapshot.houses.compactMap(\.currentDay)
+                        let avg: Int? = days.isEmpty ? nil : days.reduce(0, +) / days.count
                         let overview = FarmHomeOverview(
-                            houseCount: max(count, fallbackCount),
+                            houseCount: max(snapshot.houses.count, fallbackCount),
                             avgDayAge: avg,
-                            houseRelatedAlertCount: result.alertsSummaryTotalActive
+                            houseRelatedAlertCount: snapshot.alertsSummaryTotalActive
                         )
                         return (farmUUID, overview)
                     } catch {


### PR DESCRIPTION
## Summary

The iOS app intermittently showed missing data, partial data (only some houses populated), or inconsistent readings across houses. This PR fixes all root causes end-to-end.

**Root causes fixed:**
- **Non-atomic cache writes**: `_upsert_house_payloads` wrote each `HouseMonitoringCache` row individually — a Rotem session drop mid-scrape left some houses fresh and others stale with no rollback
- **Concurrent task overlap**: `scrape_rotem_data` and `sync_farm_data` both ran every 5 minutes writing to the same cache tables without coordination
- **3-endpoint merge on iOS**: `reloadSelectedFarmData()` fired 3 parallel requests and merged them via a fallback chain — fields from different scrape cycles appeared inconsistent

## Changes

### Backend
- **Atomic 2-phase cache commit** (`monitoring_cache_service.py`): collects all house data in memory first, then writes everything inside `transaction.atomic()` with `select_for_update()` — partial updates are impossible
- **Redis distributed lock** (`scrape_lock:farm:{id}`, 4-min TTL): prevents concurrent scrapes; degrades gracefully if Redis is unavailable
- **Per-house retry**: if 1–4 houses return `null` from Rotem, re-logins and retries just those houses before committing
- **Circuit breaker**: checks `IntegrationHealth.consecutive_failures >= 5` and short-circuits without hitting Rotem, setting `circuit_open=true` in responses
- **`house_statuses` field** on `FarmMonitoringCache` (+ migration `0011`): tracks `ok` / `stale` / `failed` per house with its own `source_timestamp`
- **Unified iOS endpoint** `GET /api/farms/<id>/ios/snapshot/`: returns all sensor data + per-house alerts from one cache row — no cross-cycle inconsistency possible
- **Task consolidation**: replaced two overlapping 5-min beat tasks with single `sync_all_farms_monitoring` fan-out; added `CELERY_TASK_ACKS_LATE=True`

### iOS
- `fetchFarmIOSSnapshot(farmID:)` method + `APIFarmIOSSnapshotResult` struct in `APIClient.swift`
- `reloadSelectedFarmData()`, `fetchFarmMonitoringDashboard()`, and `refreshFarmHomeOverviews()` in `MockDataStore.swift` all replaced with single unified snapshot call — no more 3-way merge

## Deploy order
1. Run migration `0011_farmmonitoringcache_house_statuses` first (zero-downtime, `default=dict`)
2. Deploy backend (new endpoint + service changes are backward compatible)
3. Deploy Celery workers before updating beat schedule
4. Deploy iOS app

## Test plan
- [ ] `GET /api/farms/{id}/ios/snapshot/` returns all houses with sensor data and `house_statuses`
- [ ] Trigger concurrent scrapes for same farm — second should return `status=skipped` in logs
- [ ] Set `consecutive_failures=5` on a farm's `IntegrationHealth` — cache update should return `circuit_open` without touching Rotem
- [ ] iOS: load farm screen, all houses show consistent readings, pull-to-refresh works
- [ ] iOS: `FarmMonitoringCardsView` monitoring screen shows correct per-house data

🤖 Generated with [Claude Code](https://claude.com/claude-code)