### PR TITLE
Fix SyntaxError crashing app: duplicate exc kwarg in retry call

### DIFF
--- a/backend/rotem_scraper/tasks.py
+++ b/backend/rotem_scraper/tasks.py
@@ -317,4 +317,4 @@ def calculate_daily_flock_performance(self):
     except Exception as exc:
         logger.error(f"Daily flock performance calculation failed: {str(exc)}", exc_info=True)
         # Retry in 5 minutes if failed
-        self.retry(exc=exc, countdown=300, exc=exc)
+        raise self.retry(exc=exc, countdown=300)


### PR DESCRIPTION
## Summary

- Fixes a Python `SyntaxError` introduced by the "fix backend" commit that prevents Django from starting entirely
- Every healthcheck against `/api/health/` returns **503 Service Unavailable** until this is merged and deployed

## Root cause

`calculate_daily_flock_performance` in `backend/rotem_scraper/tasks.py` contained:

```python
self.retry(exc=exc, countdown=300, exc=exc)  # ← duplicate keyword argument
```

Python raises `SyntaxError: keyword argument repeated` at import time, which means the entire `rotem_scraper` app fails to load, taking Django down with it.

## Fix

```python
raise self.retry(exc=exc, countdown=300)
```

Also added the missing `raise` so the retry actually halts execution of the task (without it, the task would continue past the retry call).

## Test plan
- [ ] Deploy and verify `/api/health/` returns 200
- [ ] Confirm Celery worker starts without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)