### PR TITLE
Fix Compare screen: feed rows dropped, water/heater dates collapse to today

### DIFF
--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -1143,19 +1143,38 @@ def house_heater_history(request, house_id):
 
     parsed = scraper.get_heater_history(house_number=house.house_number) or {}
     records = parsed.get('records', []) if isinstance(parsed, dict) else []
+
+    # Pre-compute max growth_day for relative-date fallback when batch_start_date is None.
+    valid_growth_days = []
+    for r in records:
+        gd = r.get('growth_day')
+        if gd is not None:
+            try:
+                valid_growth_days.append(int(gd))
+            except (TypeError, ValueError):
+                pass
+    max_growth_day = max(valid_growth_days) if valid_growth_days else 0
+    today = timezone.localdate()
+
     daily = []
     for r in records:
         growth_day = r.get('growth_day')
         if growth_day is None:
             continue
+        try:
+            growth_day = int(growth_day)
+        except (TypeError, ValueError):
+            continue
         dt = None
         if house.batch_start_date:
             try:
-                dt = house.batch_start_date + timedelta(days=int(growth_day))
+                dt = house.batch_start_date + timedelta(days=growth_day)
             except (TypeError, ValueError):
                 dt = None
+        if dt is None and growth_day >= 0:
+            dt = today - timedelta(days=(max_growth_day - growth_day))
         daily.append({
-            'growth_day': int(growth_day),
+            'growth_day': growth_day,
             'date': dt.isoformat() if dt else None,
             'total_hours': _safe_float(r.get('total_runtime_hours')) or 0.0,
             'total_minutes': int(r.get('total_runtime_minutes') or 0),

--- a/backend/rotem_scraper/views.py
+++ b/backend/rotem_scraper/views.py
@@ -859,12 +859,20 @@ class RotemDailySummaryViewSet(viewsets.ReadOnlyModelViewSet):
                     from datetime import timedelta
                     for record in water_history:
                         if 'growth_day' in record and record['growth_day'] >= 0:
-                            # Calculate actual date from batch_start_date + growth_day
                             actual_date = house.batch_start_date + timedelta(days=int(record['growth_day']))
                             record['date'] = actual_date.isoformat()
-                        elif 'date' in record and record['date'].startswith('Day '):
-                            # If we couldn't calculate date, keep the day format
-                            pass
+                elif water_history:
+                    # No batch_start_date: derive relative dates so iOS can chart them.
+                    # Assume the highest growth_day corresponds to today.
+                    import datetime as _dt
+                    valid_gds = [int(r['growth_day']) for r in water_history if 'growth_day' in r and r['growth_day'] >= 0]
+                    if valid_gds:
+                        max_gd = max(valid_gds)
+                        today = _dt.date.today()
+                        for record in water_history:
+                            gd = record.get('growth_day')
+                            if gd is not None and int(gd) >= 0:
+                                record['date'] = (today - timedelta(days=(max_gd - int(gd)))).isoformat()
                 
                 # Sort by growth_day or date
                 if water_history:
@@ -982,6 +990,13 @@ class RotemDailySummaryViewSet(viewsets.ReadOnlyModelViewSet):
                     'date': (house.batch_start_date + timedelta(days=growth_day)).isoformat() if house.batch_start_date else None,
                 })
             history.sort(key=lambda x: x['growth_day'])
+            # Derive relative dates when batch_start_date is absent.
+            if history and not house.batch_start_date:
+                import datetime as _dt
+                max_gd = history[-1]['growth_day']
+                today = _dt.date.today()
+                for rec in history:
+                    rec['date'] = (today - timedelta(days=(max_gd - rec['growth_day']))).isoformat()
             return Response({
                 'house_id': int(house_id),
                 'house_number': house.house_number,

--- a/mobile/ios/RotemFarm-iOS/RotemFarm/Services/APIClient.swift
+++ b/mobile/ios/RotemFarm-iOS/RotemFarm/Services/APIClient.swift
@@ -1074,10 +1074,8 @@ actor APIClient {
             throw APIClientError.decoding
         }
         return rows.compactMap { row in
-            guard
-                let growthDay = row["growth_day"] as? Int,
-                let total = row["daily_feed_total"] as? Double
-            else { return nil }
+            guard let growthDay = row["growth_day"] as? Int else { return nil }
+            let total = (row["daily_feed_total"] as? Double) ?? 0.0
             let date = (row["date"] as? String).flatMap(parseISODate)
             return APIRotemFeedHistoryPoint(
                 date: date,


### PR DESCRIPTION
## Summary

- **Feed (iOS):** `guard let total = row["daily_feed_total"] as? Double` was silently dropping every row where Rotem returns `null` for that field. Changed to `?? 0.0` so all rows are preserved and the growth-day axis stays intact.
- **Water & Feed dates (backend):** When `house.batch_start_date` is `None`, the backend emitted `"Day N"` strings instead of ISO dates. iOS `parseISODate` can't parse those, every point fell back to `Date()` (today), and `normalizeLastDays` collapsed all points to a single bucket → blank chart. Now derives proper ISO dates using `today - (max_growth_day - growth_day)` when `batch_start_date` is absent.
- **Heater dates (backend):** Same nil-date collapse in the live path of `house_heater_history`. Pre-computes `max_growth_day` upfront and applies the same relative-date fallback.

## Test plan

- [ ] Open Compare screen → Water tab: verify multi-day line chart renders for each house
- [ ] Open Compare screen → Feed tab: verify rows with null `daily_feed_total` are shown as 0 instead of missing
- [ ] Open Compare screen → Heater tab: verify multi-day line chart renders for each house
- [ ] Confirm "Today delta" KPI boxes show percentage values (not all `+0%`)
- [ ] Test with a house that has `batch_start_date` set — dates should still use the real date, not the relative fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)