### PR TITLE
feat(monitoring): cache visibility, manual refresh, and cache-only mode

### DIFF
--- a/backend/houses/management/commands/upsert_monitoring_cache.py
+++ b/backend/houses/management/commands/upsert_monitoring_cache.py
@@ -1,17 +1,20 @@
 from django.core.management.base import BaseCommand
 
-from houses.services.monitoring_cache_service import upsert_monitoring_cache_for_all_farms
+from houses.services.monitoring_cache_run_service import (
+    create_scheduled_refresh_run,
+    execute_refresh_run,
+)
 
 
 class Command(BaseCommand):
     help = "Upsert cached Rotem monitoring payloads for all active integrated farms."
 
     def handle(self, *args, **options):
-        result = upsert_monitoring_cache_for_all_farms()
+        run = execute_refresh_run(create_scheduled_refresh_run())
         self.stdout.write(
             self.style.SUCCESS(
-                f"status={result.status} farms_processed={result.farms_processed} houses_processed={result.houses_processed}"
+                f"status={run.status} farms_processed={run.farms_processed} houses_processed={run.houses_processed} run_id={run.run_id}"
             )
         )
-        if result.message:
-            self.stdout.write(self.style.WARNING(result.message))
+        if run.error_summary:
+            self.stdout.write(self.style.WARNING(run.error_summary))

--- a/backend/houses/migrations/0016_monitoring_cache_refresh_run.py
+++ b/backend/houses/migrations/0016_monitoring_cache_refresh_run.py
@@ -1,0 +1,72 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("houses", "0015_alter_housemonitoringsnapshot_timestamp"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MonitoringCacheRefreshRun",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("run_id", models.UUIDField(db_index=True, unique=True)),
+                (
+                    "trigger_type",
+                    models.CharField(
+                        choices=[("scheduled", "Scheduled"), ("manual", "Manual")],
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("queued", "Queued"),
+                            ("running", "Running"),
+                            ("success", "Success"),
+                            ("partial", "Partial"),
+                            ("failed", "Failed"),
+                        ],
+                        db_index=True,
+                        default="queued",
+                        max_length=16,
+                    ),
+                ),
+                ("started_at", models.DateTimeField(blank=True, null=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("farms_processed", models.IntegerField(default=0)),
+                ("houses_processed", models.IntegerField(default=0)),
+                ("result_payload", models.JSONField(blank=True, default=dict)),
+                ("error_summary", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "requested_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="monitoring_cache_refresh_runs",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="monitoringcacherefreshrun",
+            index=models.Index(fields=["trigger_type", "-created_at"], name="houses_moni_trigger_bdbf61_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="monitoringcacherefreshrun",
+            index=models.Index(fields=["status", "created_at"], name="houses_moni_status_4d6cda_idx"),
+        ),
+    ]

--- a/backend/houses/models.py
+++ b/backend/houses/models.py
@@ -288,6 +288,51 @@ class HouseMonitoringCache(models.Model):
         return f"House cache {self.house_id} ({self.refresh_state})"
 
 
+class MonitoringCacheRefreshRun(models.Model):
+    """Tracks scheduled and manual monitoring cache refresh runs."""
+
+    TRIGGER_CHOICES = [
+        ("scheduled", "Scheduled"),
+        ("manual", "Manual"),
+    ]
+    STATUS_CHOICES = [
+        ("queued", "Queued"),
+        ("running", "Running"),
+        ("success", "Success"),
+        ("partial", "Partial"),
+        ("failed", "Failed"),
+    ]
+
+    run_id = models.UUIDField(unique=True, db_index=True)
+    trigger_type = models.CharField(max_length=16, choices=TRIGGER_CHOICES)
+    status = models.CharField(max_length=16, choices=STATUS_CHOICES, default="queued", db_index=True)
+    started_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    farms_processed = models.IntegerField(default=0)
+    houses_processed = models.IntegerField(default=0)
+    result_payload = models.JSONField(default=dict, blank=True)
+    error_summary = models.TextField(blank=True, default="")
+    requested_by = models.ForeignKey(
+        "auth.User",
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="monitoring_cache_refresh_runs",
+    )
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["trigger_type", "-created_at"]),
+            models.Index(fields=["status", "created_at"]),
+        ]
+
+    def __str__(self):
+        return f"Monitoring cache refresh {self.run_id} ({self.status})"
+
+
 class Device(models.Model):
     """Device/equipment in a house (heaters, fans, lights, etc.)"""
     DEVICE_TYPES = [

--- a/backend/houses/services/monitoring_cache_run_service.py
+++ b/backend/houses/services/monitoring_cache_run_service.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Optional
+import os
+import uuid
+
+from django.db import connections, transaction
+from django.utils import timezone
+
+from farms.models import Farm
+from houses.models import FarmMonitoringCache, MonitoringCacheRefreshRun
+from houses.services.monitoring_cache_service import (
+    MAX_STALE_SECONDS,
+    build_meta,
+    upsert_farm_monitoring_cache,
+)
+
+
+TERMINAL_STATUSES = {"success", "partial", "failed"}
+ACTIVE_STATUSES = {"queued", "running"}
+
+
+def _run_result(run: MonitoringCacheRefreshRun) -> dict:
+    return {
+        "run_id": str(run.run_id),
+        "trigger_type": run.trigger_type,
+        "status": run.status,
+        "started_at": run.started_at.isoformat() if run.started_at else None,
+        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+        "farms_processed": run.farms_processed,
+        "houses_processed": run.houses_processed,
+        "result_payload": run.result_payload or {},
+        "error_summary": run.error_summary,
+        "created_at": run.created_at.isoformat() if run.created_at else None,
+        "updated_at": run.updated_at.isoformat() if run.updated_at else None,
+    }
+
+
+def serialize_refresh_run(run: Optional[MonitoringCacheRefreshRun]) -> Optional[dict]:
+    if not run:
+        return None
+    return _run_result(run)
+
+
+def queue_manual_refresh_run(requested_by=None) -> MonitoringCacheRefreshRun:
+    active = (
+        MonitoringCacheRefreshRun.objects.filter(trigger_type="manual", status__in=ACTIVE_STATUSES)
+        .order_by("-created_at")
+        .first()
+    )
+    if active:
+        return active
+    return MonitoringCacheRefreshRun.objects.create(
+        run_id=uuid.uuid4(),
+        trigger_type="manual",
+        status="queued",
+        requested_by=requested_by if getattr(requested_by, "is_authenticated", False) else None,
+    )
+
+
+def create_scheduled_refresh_run() -> MonitoringCacheRefreshRun:
+    return MonitoringCacheRefreshRun.objects.create(
+        run_id=uuid.uuid4(),
+        trigger_type="scheduled",
+        status="running",
+        started_at=timezone.now(),
+    )
+
+
+def claim_next_queued_manual_run() -> Optional[MonitoringCacheRefreshRun]:
+    with transaction.atomic():
+        run = (
+            MonitoringCacheRefreshRun.objects.select_for_update()
+            .filter(trigger_type="manual", status="queued")
+            .order_by("created_at")
+            .first()
+        )
+        if not run:
+            return None
+        run.status = "running"
+        run.started_at = timezone.now()
+        run.save(update_fields=["status", "started_at", "updated_at"])
+        return run
+
+
+def _refresh_one_farm(farm_id: int) -> dict:
+    try:
+        farm = Farm.objects.get(id=farm_id)
+        result = upsert_farm_monitoring_cache(farm)
+        cache = FarmMonitoringCache.objects.filter(farm=farm).first()
+        return {
+            "farm_id": farm.id,
+            "farm_name": farm.name,
+            "status": result.status,
+            "message": result.message,
+            "houses_processed": result.houses_processed,
+            "cache_fetched_at": cache.fetched_at.isoformat() if cache else None,
+            "cache_source_timestamp": cache.source_timestamp.isoformat() if cache and cache.source_timestamp else None,
+        }
+    except Exception as exc:
+        return {
+            "farm_id": farm_id,
+            "status": "failed",
+            "message": str(exc),
+            "houses_processed": 0,
+        }
+    finally:
+        connections.close_all()
+
+
+def execute_refresh_run(run: MonitoringCacheRefreshRun) -> MonitoringCacheRefreshRun:
+    if run.status != "running":
+        run.status = "running"
+        run.started_at = run.started_at or timezone.now()
+        run.save(update_fields=["status", "started_at", "updated_at"])
+
+    farm_ids = list(
+        Farm.objects.filter(
+            is_active=True,
+            has_system_integration=True,
+            integration_type="rotem",
+        ).values_list("id", flat=True)
+    )
+    max_workers = max(1, int(os.getenv("MONITORING_CACHE_REFRESH_MAX_WORKERS", "4")))
+    max_workers = min(max_workers, max(len(farm_ids), 1))
+
+    farm_results = []
+    if farm_ids:
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_refresh_one_farm, farm_id) for farm_id in farm_ids]
+            for future in as_completed(futures):
+                farm_results.append(future.result())
+
+    successes = [row for row in farm_results if row.get("status") == "success"]
+    failures = [row for row in farm_results if row.get("status") != "success"]
+    if not farm_results:
+        final_status = "success"
+    elif failures and successes:
+        final_status = "partial"
+    elif failures:
+        final_status = "failed"
+    else:
+        final_status = "success"
+
+    run.status = final_status
+    run.completed_at = timezone.now()
+    run.farms_processed = len(successes)
+    run.houses_processed = sum(int(row.get("houses_processed") or 0) for row in farm_results)
+    run.result_payload = {
+        "farm_count": len(farm_ids),
+        "max_workers": max_workers,
+        "farms": sorted(farm_results, key=lambda row: row.get("farm_id") or 0),
+    }
+    run.error_summary = "; ".join(
+        f"farm={row.get('farm_id')}:{row.get('message') or row.get('status')}" for row in failures
+    )
+    run.save()
+    connections.close_all()
+    return run
+
+
+def latest_runs() -> dict:
+    return {
+        "scheduled": serialize_refresh_run(
+            MonitoringCacheRefreshRun.objects.filter(trigger_type="scheduled").order_by("-created_at").first()
+        ),
+        "manual": serialize_refresh_run(
+            MonitoringCacheRefreshRun.objects.filter(trigger_type="manual").order_by("-created_at").first()
+        ),
+    }
+
+
+def farm_cache_status_payload(farm: Farm, interval_seconds: int = 600) -> dict:
+    cache = FarmMonitoringCache.objects.filter(farm=farm).first()
+    fetched_at = cache.fetched_at if cache else None
+    source_timestamp = cache.source_timestamp if cache else None
+    refresh_state = cache.refresh_state if cache else "missing"
+    meta = build_meta(fetched_at, source_timestamp, refresh_state, MAX_STALE_SECONDS)
+    return {
+        "farm_id": farm.id,
+        "farm_name": farm.name,
+        "cache": {
+            "exists": bool(cache),
+            "fetched_at": fetched_at.isoformat() if fetched_at else None,
+            "source_timestamp": source_timestamp.isoformat() if source_timestamp else None,
+            "age_seconds": meta.get("age_seconds"),
+            "is_stale": meta.get("is_stale"),
+            "refresh_state": refresh_state,
+            "last_error": cache.last_error if cache else "",
+        },
+        "worker_interval_seconds": interval_seconds,
+        "latest_runs": latest_runs(),
+    }

--- a/backend/houses/tests/test_monitoring_cache_refresh.py
+++ b/backend/houses/tests/test_monitoring_cache_refresh.py
@@ -1,0 +1,252 @@
+from datetime import date, timedelta
+from unittest.mock import patch
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from farms.models import Farm
+from houses.models import FarmMonitoringCache, House, MonitoringCacheRefreshRun
+from houses.services.monitoring_cache_run_service import (
+    claim_next_queued_manual_run,
+    execute_refresh_run,
+    queue_manual_refresh_run,
+)
+
+class MonitoringCacheRefreshTestBase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user(
+            username="monitoring_cache_tester",
+            email="monitoring-cache@test.com",
+            password="testpass123",
+            is_staff=True,
+        )
+        self.client.force_authenticate(user=self.user)
+
+        self.farm = Farm.objects.create(
+            name="Cache Test Farm",
+            location="Test",
+            contact_person="Owner",
+            contact_phone="0000000099",
+            contact_email="cache-owner@example.com",
+            integration_type="rotem",
+            integration_status="active",
+            has_system_integration=True,
+            is_active=True,
+            rotem_farm_id="cache-farm",
+            rotem_username="cache_user",
+            rotem_password="cache_pass",
+        )
+        self.house = House.objects.create(
+            farm=self.farm,
+            house_number=1,
+            chicken_in_date=date.today() - timedelta(days=10),
+            is_active=True,
+            is_integrated=True,
+        )
+        self.dashboard_payload = {
+            "farm_id": self.farm.id,
+            "farm_name": self.farm.name,
+            "total_houses": 1,
+            "houses": [{"house_id": self.house.id, "house_number": 1}],
+            "alerts_summary": {"total_active": 0, "critical": 0, "warning": 0, "normal": 1},
+            "connection_summary": {"connected": 1, "disconnected": 0},
+        }
+
+
+class CacheOnlyModeTests(MonitoringCacheRefreshTestBase):
+    def test_cache_only_dashboard_returns_cache_without_rotem(self):
+        cache = FarmMonitoringCache.objects.create(
+            farm=self.farm,
+            dashboard_payload=self.dashboard_payload,
+            source_timestamp=timezone.now(),
+            refresh_state="fresh",
+        )
+        FarmMonitoringCache.objects.filter(id=cache.id).update(
+            fetched_at=timezone.now() - timedelta(minutes=2)
+        )
+
+        url = reverse("farm-houses-monitoring-dashboard", kwargs={"farm_id": self.farm.id})
+        with patch("houses.views._ensure_farm_cache") as mock_ensure, patch(
+            "houses.views.RotemScraper"
+        ) as mock_scraper:
+            response = self.client.get(url, {"mode": "cache_only"})
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["data"]["total_houses"], 1)
+        self.assertIn("meta", body)
+        mock_ensure.assert_not_called()
+        mock_scraper.assert_not_called()
+
+    def test_cache_only_missing_cache_returns_empty_payload_with_metadata(self):
+        url = reverse("farm-houses-monitoring-dashboard", kwargs={"farm_id": self.farm.id})
+        with patch("houses.views._ensure_farm_cache") as mock_ensure, patch(
+            "houses.views.RotemScraper"
+        ) as mock_scraper:
+            response = self.client.get(url, {"mode": "cache_only"})
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["data"]["total_houses"], 0)
+        self.assertEqual(body["meta"]["refresh_state"], "missing")
+        mock_ensure.assert_not_called()
+        mock_scraper.assert_not_called()
+
+
+class MonitoringCacheRefreshApiTests(MonitoringCacheRefreshTestBase):
+    def test_manual_refresh_queue_returns_run_id(self):
+        url = reverse("monitoring-cache-refresh-queue")
+        response = self.client.post(url, {}, format="json")
+
+        self.assertIn(response.status_code, (status.HTTP_200_OK, status.HTTP_202_ACCEPTED))
+        body = response.json()
+        self.assertIn("run_id", body)
+        self.assertEqual(body["trigger_type"], "manual")
+        self.assertEqual(body["status"], "queued")
+        run = MonitoringCacheRefreshRun.objects.get(run_id=body["run_id"])
+        self.assertEqual(run.requested_by_id, self.user.id)
+
+    def test_manual_refresh_dedupes_active_run(self):
+        url = reverse("monitoring-cache-refresh-queue")
+        first = self.client.post(url, {}, format="json").json()
+        second = self.client.post(url, {}, format="json").json()
+        self.assertEqual(first["run_id"], second["run_id"])
+        self.assertEqual(
+            MonitoringCacheRefreshRun.objects.filter(trigger_type="manual").count(),
+            1,
+        )
+
+    def test_refresh_run_detail_returns_status(self):
+        run = MonitoringCacheRefreshRun.objects.create(
+            run_id=uuid.uuid4(),
+            trigger_type="manual",
+            status="success",
+            farms_processed=1,
+            houses_processed=2,
+            completed_at=timezone.now(),
+        )
+        url = reverse("monitoring-cache-refresh-run-detail", kwargs={"run_id": run.run_id})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["run_id"], str(run.run_id))
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["houses_processed"], 2)
+
+
+class FarmCacheStatusTests(MonitoringCacheRefreshTestBase):
+    def test_cache_status_reports_freshness_and_latest_runs(self):
+        fetched_at = timezone.now() - timedelta(minutes=12)
+        cache = FarmMonitoringCache.objects.create(
+            farm=self.farm,
+            dashboard_payload=self.dashboard_payload,
+            source_timestamp=fetched_at,
+            refresh_state="stale",
+        )
+        FarmMonitoringCache.objects.filter(id=cache.id).update(fetched_at=fetched_at)
+
+        scheduled = MonitoringCacheRefreshRun.objects.create(
+            run_id=uuid.uuid4(),
+            trigger_type="scheduled",
+            status="success",
+            completed_at=timezone.now(),
+        )
+        manual = MonitoringCacheRefreshRun.objects.create(
+            run_id=uuid.uuid4(),
+            trigger_type="manual",
+            status="partial",
+            completed_at=timezone.now(),
+        )
+
+        url = reverse("farm-monitoring-cache-status", kwargs={"farm_id": self.farm.id})
+        with patch.dict("os.environ", {"MONITORING_CACHE_INTERVAL_SECONDS": "600"}):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body["farm_id"], self.farm.id)
+        self.assertTrue(body["cache"]["exists"])
+        self.assertIsNotNone(body["cache"]["fetched_at"])
+        self.assertGreater(body["cache"]["age_seconds"], 0)
+        self.assertTrue(body["cache"]["is_stale"])
+        self.assertEqual(body["worker_interval_seconds"], 600)
+        self.assertEqual(body["latest_runs"]["scheduled"]["run_id"], str(scheduled.run_id))
+        self.assertEqual(body["latest_runs"]["manual"]["status"], "partial")
+
+
+class MonitoringCacheRunServiceTests(MonitoringCacheRefreshTestBase):
+    def test_claim_next_queued_manual_run_marks_running(self):
+        run = MonitoringCacheRefreshRun.objects.create(
+            run_id=uuid.uuid4(),
+            trigger_type="manual",
+            status="queued",
+        )
+        claimed = claim_next_queued_manual_run()
+        self.assertIsNotNone(claimed)
+        self.assertEqual(str(claimed.run_id), str(run.run_id))
+        run.refresh_from_db()
+        self.assertEqual(run.status, "running")
+        self.assertIsNotNone(run.started_at)
+
+    @patch("houses.services.monitoring_cache_run_service._refresh_one_farm")
+    def test_execute_refresh_run_records_partial_when_some_farms_fail(self, mock_refresh):
+        other_farm = Farm.objects.create(
+            name="Other Cache Farm",
+            location="Test",
+            contact_person="Owner",
+            contact_phone="0000000100",
+            contact_email="other-cache@example.com",
+            integration_type="rotem",
+            integration_status="active",
+            has_system_integration=True,
+            is_active=True,
+            rotem_farm_id="other-cache-farm",
+        )
+
+        def side_effect(farm_id: int):
+            if farm_id == self.farm.id:
+                return {
+                    "farm_id": self.farm.id,
+                    "farm_name": self.farm.name,
+                    "status": "success",
+                    "message": "ok",
+                    "houses_processed": 1,
+                }
+            return {
+                "farm_id": farm_id,
+                "status": "failed",
+                "message": "login_failed",
+                "houses_processed": 0,
+            }
+
+        mock_refresh.side_effect = side_effect
+
+        run = MonitoringCacheRefreshRun.objects.create(
+            run_id=uuid.uuid4(),
+            trigger_type="manual",
+            status="running",
+            started_at=timezone.now(),
+        )
+        finished = execute_refresh_run(run)
+        self.assertEqual(finished.status, "partial")
+        self.assertEqual(finished.farms_processed, 1)
+        self.assertEqual(finished.houses_processed, 1)
+        self.assertIn("login_failed", finished.error_summary)
+        farm_rows = {row["farm_id"]: row for row in finished.result_payload["farms"]}
+        self.assertEqual(farm_rows[self.farm.id]["status"], "success")
+        self.assertEqual(farm_rows[other_farm.id]["status"], "failed")
+
+    @patch("houses.services.monitoring_cache_run_service.upsert_farm_monitoring_cache")
+    def test_queue_manual_refresh_run_creates_queued_run(self, mock_upsert):
+        run = queue_manual_refresh_run(self.user)
+        self.assertEqual(run.status, "queued")
+        self.assertEqual(run.trigger_type, "manual")
+        mock_upsert.assert_not_called()

--- a/backend/houses/urls.py
+++ b/backend/houses/urls.py
@@ -21,6 +21,9 @@ urlpatterns = [
     path('farms/<int:farm_id>/houses/monitoring/dashboard/', views.farm_houses_monitoring_dashboard, name='farm-houses-monitoring-dashboard'),
     path('farms/<int:farm_id>/houses/monitoring/snapshot/', views.farm_houses_monitoring_snapshot, name='farm-houses-monitoring-snapshot'),
     path('farms/<int:farm_id>/houses/monitoring/refresh/', views.farm_monitoring_refresh, name='farm-monitoring-refresh'),
+    path('farms/<int:farm_id>/houses/monitoring/cache-status/', views.farm_monitoring_cache_status, name='farm-monitoring-cache-status'),
+    path('farms/monitoring/cache-refresh/', views.monitoring_cache_refresh_queue, name='monitoring-cache-refresh-queue'),
+    path('farms/monitoring/cache-refresh/<uuid:run_id>/', views.monitoring_cache_refresh_run_detail, name='monitoring-cache-refresh-run-detail'),
     path('farms/<int:farm_id>/houses/water-history-comparison/', views.farm_water_history_comparison, name='farm-water-history-comparison'),
     path('farms/<int:farm_id>/ios/snapshot/', views.farm_ios_snapshot, name='farm-ios-snapshot'),
     

--- a/backend/houses/views.py
+++ b/backend/houses/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -8,6 +10,7 @@ from django.utils import timezone
 from datetime import timedelta, datetime, date
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import logging
+import os
 from .models import (
     House,
     HouseMonitoringSnapshot,
@@ -49,7 +52,12 @@ from .services.monitoring_cache_service import (
     upsert_farm_monitoring_cache,
     wrap_cached_response,
 )
-from .models import FarmMonitoringCache, HouseMonitoringCache
+from .services.monitoring_cache_run_service import (
+    farm_cache_status_payload,
+    queue_manual_refresh_run,
+    serialize_refresh_run,
+)
+from .models import FarmMonitoringCache, HouseMonitoringCache, MonitoringCacheRefreshRun
 from rotem_scraper.tasks import sync_refresh_house_heater_history
 from farms.views import user_accessible_organization_ids
 from rotem_scraper.scraper import RotemScraper
@@ -59,9 +67,18 @@ logger = logging.getLogger(__name__)
 
 def _cache_mode(request):
     mode = (request.query_params.get('mode') or 'cached_then_live').lower()
-    if mode not in ('cached', 'live', 'cached_then_live'):
-        return 'cached'
+    if mode not in ('cached', 'cache_only', 'live', 'cached_then_live'):
+        return 'cached_then_live'
     return mode
+
+
+def _cache_only_meta(cache, refresh_state='missing'):
+    return build_meta(
+        fetched_at=getattr(cache, 'fetched_at', None),
+        source_timestamp=getattr(cache, 'source_timestamp', None),
+        refresh_state=getattr(cache, 'refresh_state', refresh_state),
+        stale_seconds=MAX_STALE_SECONDS,
+    )
 
 
 def _should_refresh(meta: dict):
@@ -930,7 +947,9 @@ def house_monitoring_latest(request, house_id):
     house = _house_from_scope_or_404(request, house_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_house_cache(house, 'latest_payload', force=(mode == 'live'))
+        HouseMonitoringCache.objects.filter(house=house).first()
+        if mode == 'cache_only'
+        else _ensure_house_cache(house, 'latest_payload', force=(mode == 'live'))
         if mode != 'live'
         else HouseMonitoringCache.objects.filter(house=house).first()
     )
@@ -942,6 +961,8 @@ def house_monitoring_latest(request, house_id):
             stale_seconds=MAX_STALE_SECONDS,
         )
         return Response(wrap_cached_response(cache.latest_payload, meta))
+    if mode == 'cache_only':
+        return Response(wrap_cached_response(None, _cache_only_meta(cache)))
 
     scraper, err = _house_rotem_scraper_or_error(house)
     if err:
@@ -988,13 +1009,18 @@ def house_monitoring_history(request, house_id):
     house = _house_from_scope_or_404(request, house_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_house_cache(house, 'history_payload', force=(mode == 'live'))
+        HouseMonitoringCache.objects.filter(house=house).first()
+        if mode == 'cache_only'
+        else _ensure_house_cache(house, 'history_payload', force=(mode == 'live'))
         if mode != 'live'
         else HouseMonitoringCache.objects.filter(house=house).first()
     )
     if mode != 'live' and cache and cache.history_payload:
         meta = build_meta(cache.fetched_at, cache.source_timestamp, cache.refresh_state, MAX_STALE_SECONDS)
         return Response(wrap_cached_response(cache.history_payload, meta))
+    if mode == 'cache_only':
+        payload = {'count': 0, 'results': [], 'detail': 'No cached monitoring history available.'}
+        return Response(wrap_cached_response(payload, _cache_only_meta(cache)))
 
     scraper, err = _house_rotem_scraper_or_error(house)
     if err:
@@ -1126,13 +1152,18 @@ def house_monitoring_kpis(request, house_id):
     house = _house_from_scope_or_404(request, house_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_house_cache(house, 'kpis_payload', force=(mode == 'live'))
+        HouseMonitoringCache.objects.filter(house=house).first()
+        if mode == 'cache_only'
+        else _ensure_house_cache(house, 'kpis_payload', force=(mode == 'live'))
         if mode != 'live'
         else HouseMonitoringCache.objects.filter(house=house).first()
     )
     if mode != 'live' and cache and cache.kpis_payload:
         meta = build_meta(cache.fetched_at, cache.source_timestamp, cache.refresh_state, MAX_STALE_SECONDS)
         return Response(wrap_cached_response(cache.kpis_payload, meta))
+    if mode == 'cache_only':
+        payload = {'house_id': house.id, 'detail': 'No cached monitoring KPI data available.'}
+        return Response(wrap_cached_response(payload, _cache_only_meta(cache)))
 
     scraper, err = _house_rotem_scraper_or_error(house)
     if err:
@@ -1259,13 +1290,18 @@ def farm_houses_monitoring_all(request, farm_id):
     farm = get_object_or_404(_scoped_farms_queryset(request), id=farm_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_farm_cache(farm, force=(mode == 'live'))
+        FarmMonitoringCache.objects.filter(farm=farm).first()
+        if mode == 'cache_only'
+        else _ensure_farm_cache(farm, force=(mode == 'live'))
         if mode != 'live'
         else FarmMonitoringCache.objects.filter(farm=farm).first()
     )
     if mode != 'live' and cache and cache.houses_payload:
         meta = build_meta(cache.fetched_at, cache.source_timestamp, cache.refresh_state, MAX_STALE_SECONDS)
         return Response(wrap_cached_response(cache.houses_payload, meta))
+    if mode == 'cache_only':
+        payload = {'farm_id': farm.id, 'farm_name': farm.name, 'houses_count': 0, 'houses': []}
+        return Response(wrap_cached_response(payload, _cache_only_meta(cache)))
 
     houses = list(House.objects.filter(farm=farm, is_active=True).order_by('house_number'))
     if not houses:
@@ -1334,7 +1370,9 @@ def farm_houses_monitoring_dashboard(request, farm_id):
     farm = get_object_or_404(_scoped_farms_queryset(request), id=farm_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_farm_cache(farm, force=(mode == 'live'))
+        FarmMonitoringCache.objects.filter(farm=farm).first()
+        if mode == 'cache_only'
+        else _ensure_farm_cache(farm, force=(mode == 'live'))
         if mode != 'live'
         else FarmMonitoringCache.objects.filter(farm=farm).first()
     )
@@ -1358,6 +1396,16 @@ def farm_houses_monitoring_dashboard(request, farm_id):
                     'connection_summary': {'connected': len(fallback_houses), 'disconnected': 0},
                 }
         return Response(wrap_cached_response(payload, meta))
+    if mode == 'cache_only':
+        dashboard_data = {
+            'farm_id': farm_id,
+            'farm_name': farm.name,
+            'total_houses': 0,
+            'houses': [],
+            'alerts_summary': {'total_active': 0, 'critical': 0, 'warning': 0, 'normal': 0},
+            'connection_summary': {'connected': 0, 'disconnected': 0},
+        }
+        return Response(wrap_cached_response(dashboard_data, _cache_only_meta(cache)))
 
     houses = list(House.objects.filter(farm=farm, is_active=True).order_by('house_number'))
     dashboard_data = {
@@ -1439,7 +1487,9 @@ def farm_houses_monitoring_snapshot(request, farm_id):
     farm = get_object_or_404(_scoped_farms_queryset(request), id=farm_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_farm_cache(farm, force=(mode == 'live'))
+        FarmMonitoringCache.objects.filter(farm=farm).first()
+        if mode == 'cache_only'
+        else _ensure_farm_cache(farm, force=(mode == 'live'))
         if mode != 'live'
         else FarmMonitoringCache.objects.filter(farm=farm).first()
     )
@@ -1454,6 +1504,17 @@ def farm_houses_monitoring_snapshot(request, farm_id):
         )
         meta = build_meta(cache.fetched_at, cache.source_timestamp, cache.refresh_state, MAX_STALE_SECONDS)
         return Response(wrap_cached_response(snapshot, meta))
+    if mode == 'cache_only':
+        snapshot = {
+            'farm_id': farm.id,
+            'farm_name': farm.name,
+            'total_houses': 0,
+            'houses': [],
+            'alerts_by_house': {},
+            'alerts_summary': {'total_active': 0, 'critical': 0, 'warning': 0, 'normal': 0},
+            'connection_summary': {'connected': 0, 'disconnected': 0},
+        }
+        return Response(wrap_cached_response(snapshot, _cache_only_meta(cache)))
 
     if not houses:
         snapshot = {
@@ -1609,13 +1670,17 @@ def house_heater_history(request, house_id):
     house = _house_from_scope_or_404(request, house_id)
     mode = _cache_mode(request)
     cache = (
-        _ensure_house_cache(house, 'heater_payload', force=(mode == 'live'))
+        HouseMonitoringCache.objects.filter(house=house).first()
+        if mode == 'cache_only'
+        else _ensure_house_cache(house, 'heater_payload', force=(mode == 'live'))
         if mode != 'live'
         else HouseMonitoringCache.objects.filter(house=house).first()
     )
     if mode != 'live' and cache and cache.heater_payload:
         meta = build_meta(cache.fetched_at, cache.source_timestamp, cache.refresh_state, MAX_STALE_SECONDS)
         return Response(wrap_cached_response(cache.heater_payload, meta))
+    if mode == 'cache_only':
+        return Response(wrap_cached_response({'heater_history': {'daily': []}}, _cache_only_meta(cache)))
 
     scraper, err = _house_rotem_scraper_or_error(house)
     if err:
@@ -1721,6 +1786,32 @@ def farm_monitoring_refresh(request, farm_id):
         },
         status=status.HTTP_200_OK if result.status in ('success', 'partial') else status.HTTP_502_BAD_GATEWAY,
     )
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def monitoring_cache_refresh_queue(request):
+    """Queue a non-blocking manual monitoring cache refresh for all active Rotem farms."""
+    run = queue_manual_refresh_run(request.user)
+    response_status = status.HTTP_202_ACCEPTED if run.status in ('queued', 'running') else status.HTTP_200_OK
+    return Response(serialize_refresh_run(run), status=response_status)
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def monitoring_cache_refresh_run_detail(request, run_id):
+    """Return current status for a monitoring cache refresh run."""
+    run = get_object_or_404(MonitoringCacheRefreshRun, run_id=run_id)
+    return Response(serialize_refresh_run(run))
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def farm_monitoring_cache_status(request, farm_id):
+    """Return current monitoring cache freshness and latest refresh runs for a farm."""
+    farm = get_object_or_404(_scoped_farms_queryset(request), id=farm_id)
+    interval = int(os.getenv("MONITORING_CACHE_INTERVAL_SECONDS", "600"))
+    return Response(farm_cache_status_payload(farm, interval_seconds=interval))
 
 
 @api_view(['GET'])

--- a/backend/monitoring_cache_worker.py
+++ b/backend/monitoring_cache_worker.py
@@ -13,7 +13,6 @@ import sys
 import time
 
 import django
-from django.core.management import call_command
 from django.db import connections
 from django.utils import timezone
 
@@ -43,13 +42,35 @@ def main():
         flush=True,
     )
     django.setup()
+    from houses.services.monitoring_cache_run_service import (
+        claim_next_queued_manual_run,
+        create_scheduled_refresh_run,
+        execute_refresh_run,
+    )
+
     interval = int(os.getenv("MONITORING_CACHE_INTERVAL_SECONDS", "600"))
+    manual_poll_seconds = max(1, int(os.getenv("MONITORING_CACHE_MANUAL_POLL_SECONDS", "5")))
+
+    def process_queued_manual_runs():
+        while running:
+            manual_run = claim_next_queued_manual_run()
+            if not manual_run:
+                return
+            print(
+                f"monitoring_cache_worker manual_run_start run_id={manual_run.run_id}",
+                flush=True,
+            )
+            execute_refresh_run(manual_run)
+            print(
+                f"monitoring_cache_worker manual_run_finish run_id={manual_run.run_id} status={manual_run.status}",
+                flush=True,
+            )
 
     while running:
         started = timezone.now()
         print(f"monitoring_cache_worker tick_start={started.isoformat()}", flush=True)
         try:
-            call_command("upsert_monitoring_cache")
+            execute_refresh_run(create_scheduled_refresh_run())
         except Exception as exc:
             print(f"monitoring_cache_worker status=error error={exc}", flush=True)
         finally:
@@ -63,10 +84,14 @@ def main():
         )
 
         sleep_for = max(interval - elapsed, 1)
-        for _ in range(sleep_for):
+        slept = 0
+        while slept < sleep_for:
             if not running:
                 break
-            time.sleep(1)
+            process_queued_manual_runs()
+            chunk = min(manual_poll_seconds, sleep_for - slept)
+            time.sleep(chunk)
+            slept += chunk
 
     print("monitoring_cache_worker status=stopping", flush=True)
     connections.close_all()

--- a/frontend/src/components/farms/UnifiedFarmDashboard.tsx
+++ b/frontend/src/components/farms/UnifiedFarmDashboard.tsx
@@ -29,6 +29,9 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import {
   Settings,
@@ -62,7 +65,12 @@ import EmailManager from '../EmailManager';
 import WorkerList from '../WorkerList';
 import FarmHousesMonitoring from '../houses/FarmHousesMonitoring';
 import monitoringApi from '../../services/monitoringApi';
-import { MonitoringDashboardData } from '../../types/monitoring';
+import {
+  FarmMonitoringCacheStatus,
+  MonitoringCacheRefreshRun,
+  MonitoringDashboardData,
+  MonitoringDataMode,
+} from '../../types/monitoring';
 import MonitoringDataQualityPanel from '../monitoring/MonitoringDataQualityPanel';
 import IntegrationManagement from './IntegrationManagement';
 import { useProgram } from '../../contexts/ProgramContext';
@@ -229,7 +237,12 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
   const [mlPredictions, setMlPredictions] = useState<MLPrediction[]>([]);
   const [loadingData, setLoadingData] = useState(false);
   const [monitoringDashboard, setMonitoringDashboard] = useState<MonitoringDashboard | null>(null);
+  const [monitoringCacheStatus, setMonitoringCacheStatus] = useState<FarmMonitoringCacheStatus | null>(null);
+  const [monitoringDataMode, setMonitoringDataMode] = useState<MonitoringDataMode>(() => monitoringApi.getMonitoringDataMode());
+  const [monitoringRefreshRun, setMonitoringRefreshRun] = useState<MonitoringCacheRefreshRun | null>(null);
   const [loadingMonitoring, setLoadingMonitoring] = useState(false);
+  const [queueingMonitoringRefresh, setQueueingMonitoringRefresh] = useState(false);
+  const [clockNow, setClockNow] = useState(() => Date.now());
   const [integrationDialogOpen, setIntegrationDialogOpen] = useState(false);
   
   // Water anomaly detection state
@@ -271,14 +284,38 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
       fetchMlPredictions();
       fetchMonitoringDashboard();
     }
-  }, [farm?.id, farm?.integration_type]);
+  }, [farm?.id, farm?.integration_type, monitoringDataMode]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setClockNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!monitoringRefreshRun || !['queued', 'running'].includes(monitoringRefreshRun.status)) return undefined;
+    const interval = setInterval(async () => {
+      try {
+        const run = await monitoringApi.getMonitoringCacheRefreshRun(monitoringRefreshRun.run_id);
+        setMonitoringRefreshRun(run);
+        if (!['queued', 'running'].includes(run.status)) {
+          fetchMonitoringDashboard();
+        }
+      } catch (error) {
+        console.error('Error polling monitoring refresh run:', error);
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [monitoringRefreshRun?.run_id, monitoringRefreshRun?.status]);
 
   const fetchMonitoringDashboard = async () => {
     if (!farm) return;
     
     setLoadingMonitoring(true);
     try {
-      const data = await monitoringApi.getFarmMonitoringDashboard(farm.id);
+      const [data, status] = await Promise.all([
+        monitoringApi.getFarmMonitoringDashboard(farm.id, monitoringDataMode),
+        monitoringApi.getFarmMonitoringCacheStatus(farm.id),
+      ]);
       // Transform MonitoringDashboardData to MonitoringDashboard format
       const transformedData: MonitoringDashboard = {
         total_houses: data.total_houses,
@@ -299,10 +336,49 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
         })),
       };
       setMonitoringDashboard(transformedData);
+      setMonitoringCacheStatus(status);
+      setMonitoringRefreshRun(status.latest_runs.manual?.status === 'queued' || status.latest_runs.manual?.status === 'running'
+        ? status.latest_runs.manual
+        : null);
     } catch (error) {
       console.error('Error fetching monitoring dashboard:', error);
     } finally {
       setLoadingMonitoring(false);
+    }
+  };
+
+  const formatMonitoringDateTime = (value?: string | null) => {
+    if (!value) return 'Never';
+    return new Date(value).toLocaleString();
+  };
+
+  const formatMonitoringAge = (value?: string | null) => {
+    if (!value) return 'Unknown';
+    const seconds = Math.max(0, Math.floor((clockNow - new Date(value).getTime()) / 1000));
+    if (seconds < 60) return `${seconds} sec ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes} min ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} hr ago`;
+    return `${Math.floor(hours / 24)} days ago`;
+  };
+
+  const handleMonitoringDataModeChange = (_event: React.MouseEvent<HTMLElement>, value: MonitoringDataMode | null) => {
+    if (!value) return;
+    monitoringApi.setMonitoringDataMode(value);
+    setMonitoringDataMode(value);
+  };
+
+  const handleQueueMonitoringRefresh = async () => {
+    setQueueingMonitoringRefresh(true);
+    try {
+      const run = await monitoringApi.queueMonitoringCacheRefresh();
+      setMonitoringRefreshRun(run);
+    } catch (error) {
+      console.error('Error queueing monitoring refresh:', error);
+      setError('Failed to queue monitoring cache refresh');
+    } finally {
+      setQueueingMonitoringRefresh(false);
     }
   };
 
@@ -1320,7 +1396,29 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
                 <Typography variant="h6">
                   Monitoring Dashboard
                 </Typography>
-                <Box display="flex" gap={1}>
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <ToggleButtonGroup
+                    size="small"
+                    exclusive
+                    value={monitoringDataMode}
+                    onChange={handleMonitoringDataModeChange}
+                  >
+                    <ToggleButton value="cache_only">Job cache</ToggleButton>
+                    <ToggleButton value="cached_then_live">Current</ToggleButton>
+                  </ToggleButtonGroup>
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={
+                      queueingMonitoringRefresh || monitoringRefreshRun?.status === 'queued' || monitoringRefreshRun?.status === 'running'
+                        ? <CircularProgress size={16} color="inherit" />
+                        : <Refresh />
+                    }
+                    onClick={handleQueueMonitoringRefresh}
+                    disabled={queueingMonitoringRefresh || monitoringRefreshRun?.status === 'queued' || monitoringRefreshRun?.status === 'running'}
+                  >
+                    Run now
+                  </Button>
                   <Button
                     variant="outlined"
                     size="small"
@@ -1338,8 +1436,43 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
                   >
                     View All Houses
                   </Button>
-                </Box>
+                </Stack>
               </Box>
+
+              {monitoringCacheStatus && (
+                <Alert
+                  severity={monitoringCacheStatus.cache.is_stale ? 'warning' : 'success'}
+                  sx={{ mb: 2 }}
+                  action={
+                    <Chip
+                      size="small"
+                      color={monitoringCacheStatus.cache.is_stale ? 'warning' : 'success'}
+                      label={monitoringCacheStatus.cache.refresh_state}
+                    />
+                  }
+                >
+                  Last fetched: {formatMonitoringDateTime(monitoringCacheStatus.cache.fetched_at)} · Data age: {formatMonitoringAge(monitoringCacheStatus.cache.fetched_at)}
+                  {monitoringCacheStatus.latest_runs.scheduled && (
+                    <> · Last scheduled run: {monitoringCacheStatus.latest_runs.scheduled.status}</>
+                  )}
+                  {monitoringCacheStatus.latest_runs.manual && (
+                    <> · Last manual run: {monitoringCacheStatus.latest_runs.manual.status}</>
+                  )}
+                </Alert>
+              )}
+
+              {monitoringRefreshRun && (
+                <Alert
+                  severity={monitoringRefreshRun.status === 'failed' ? 'error' : monitoringRefreshRun.status === 'partial' ? 'warning' : 'info'}
+                  sx={{ mb: 2 }}
+                >
+                  Manual refresh {monitoringRefreshRun.status}
+                  {monitoringRefreshRun.farms_processed || monitoringRefreshRun.houses_processed
+                    ? ` · farms ${monitoringRefreshRun.farms_processed} · houses ${monitoringRefreshRun.houses_processed}`
+                    : ''}
+                  {monitoringRefreshRun.error_summary ? ` · ${monitoringRefreshRun.error_summary}` : ''}
+                </Alert>
+              )}
 
               {loadingMonitoring ? (
                 <Box display="flex" justifyContent="center" p={3}>

--- a/frontend/src/components/houses/FarmHousesMonitoring.tsx
+++ b/frontend/src/components/houses/FarmHousesMonitoring.tsx
@@ -11,6 +11,10 @@ import {
   Alert,
   IconButton,
   Tooltip,
+  Button,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import {
   Refresh,
@@ -23,14 +27,25 @@ import {
   Air,
 } from '@mui/icons-material';
 import monitoringApi from '../../services/monitoringApi';
-import { FarmHousesMonitoringResponse, HouseMonitoringSummary } from '../../types/monitoring';
+import {
+  FarmHousesMonitoringResponse,
+  FarmMonitoringCacheStatus,
+  HouseMonitoringSummary,
+  MonitoringCacheRefreshRun,
+  MonitoringDataMode,
+} from '../../types/monitoring';
 
 const FarmHousesMonitoring: React.FC = () => {
   const { farmId } = useParams<{ farmId: string }>();
   const navigate = useNavigate();
   const [data, setData] = useState<FarmHousesMonitoringResponse | null>(null);
+  const [cacheStatus, setCacheStatus] = useState<FarmMonitoringCacheStatus | null>(null);
+  const [dataMode, setDataMode] = useState<MonitoringDataMode>(() => monitoringApi.getMonitoringDataMode());
+  const [activeRun, setActiveRun] = useState<MonitoringCacheRefreshRun | null>(null);
   const [loading, setLoading] = useState(true);
+  const [runningNow, setRunningNow] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
 
   const fetchMonitoringData = async () => {
     if (!farmId) return;
@@ -38,8 +53,16 @@ const FarmHousesMonitoring: React.FC = () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await monitoringApi.getFarmHousesMonitoring(parseInt(farmId));
+      const farmIdNumber = parseInt(farmId);
+      const [response, statusResponse] = await Promise.all([
+        monitoringApi.getFarmHousesMonitoring(farmIdNumber, dataMode),
+        monitoringApi.getFarmMonitoringCacheStatus(farmIdNumber),
+      ]);
       setData(response);
+      setCacheStatus(statusResponse);
+      setActiveRun(statusResponse.latest_runs.manual?.status === 'queued' || statusResponse.latest_runs.manual?.status === 'running'
+        ? statusResponse.latest_runs.manual
+        : null);
     } catch (err: any) {
       setError(err.response?.data?.message || 'Failed to fetch monitoring data');
     } finally {
@@ -52,7 +75,47 @@ const FarmHousesMonitoring: React.FC = () => {
     // Auto-refresh every 30 seconds
     const interval = setInterval(fetchMonitoringData, 30000);
     return () => clearInterval(interval);
-  }, [farmId]);
+  }, [farmId, dataMode]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (!activeRun || !['queued', 'running'].includes(activeRun.status)) return undefined;
+    const interval = setInterval(async () => {
+      try {
+        const run = await monitoringApi.getMonitoringCacheRefreshRun(activeRun.run_id);
+        setActiveRun(run);
+        if (!['queued', 'running'].includes(run.status)) {
+          fetchMonitoringData();
+        }
+      } catch (err) {
+        console.error('Failed to poll monitoring cache refresh run:', err);
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [activeRun?.run_id, activeRun?.status]);
+
+  const handleDataModeChange = (_event: React.MouseEvent<HTMLElement>, value: MonitoringDataMode | null) => {
+    if (!value) return;
+    monitoringApi.setMonitoringDataMode(value);
+    setDataMode(value);
+  };
+
+  const handleRunNow = async () => {
+    setRunningNow(true);
+    setError(null);
+    try {
+      const run = await monitoringApi.queueMonitoringCacheRefresh();
+      setActiveRun(run);
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Failed to queue monitoring cache refresh');
+    } finally {
+      setRunningNow(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -70,7 +133,7 @@ const FarmHousesMonitoring: React.FC = () => {
     );
   }
 
-  if (!data || data.houses.length === 0) {
+  if (!data) {
     return (
       <Box p={3}>
         <Alert severity="info">No monitoring data available for houses in this farm</Alert>
@@ -94,6 +157,22 @@ const FarmHousesMonitoring: React.FC = () => {
     return `${value.toFixed(1)} ${unit}`;
   };
 
+  const formatDateTime = (value?: string | null) => {
+    if (!value) return 'Never';
+    return new Date(value).toLocaleString();
+  };
+
+  const formatAge = (value?: string | null) => {
+    if (!value) return 'Unknown';
+    const seconds = Math.max(0, Math.floor((now - new Date(value).getTime()) / 1000));
+    if (seconds < 60) return `${seconds} sec ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes} min ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours} hr ago`;
+    return `${Math.floor(hours / 24)} days ago`;
+  };
+
   const getHouseStatus = (house: HouseMonitoringSummary | any) => {
     if (house.status === 'no_data') return 'no_data';
     if (!house.is_connected) return 'disconnected';
@@ -108,12 +187,70 @@ const FarmHousesMonitoring: React.FC = () => {
         <Typography variant="h5">
           {data.farm_name} - Houses Monitoring ({data.houses_count} houses)
         </Typography>
-        <Tooltip title="Refresh">
-          <IconButton onClick={fetchMonitoringData}>
-            <Refresh />
-          </IconButton>
-        </Tooltip>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={dataMode}
+            onChange={handleDataModeChange}
+          >
+            <ToggleButton value="cache_only">Job cache</ToggleButton>
+            <ToggleButton value="cached_then_live">Current</ToggleButton>
+          </ToggleButtonGroup>
+          <Button
+            size="small"
+            variant="contained"
+            startIcon={runningNow || activeRun?.status === 'queued' || activeRun?.status === 'running' ? <CircularProgress size={16} color="inherit" /> : <Refresh />}
+            onClick={handleRunNow}
+            disabled={runningNow || activeRun?.status === 'queued' || activeRun?.status === 'running'}
+          >
+            Run now
+          </Button>
+          <Tooltip title="Reload displayed data">
+            <IconButton onClick={fetchMonitoringData}>
+              <Refresh />
+            </IconButton>
+          </Tooltip>
+        </Stack>
       </Box>
+
+      {cacheStatus && (
+        <Alert
+          severity={cacheStatus.cache.is_stale ? 'warning' : 'success'}
+          sx={{ mb: 2 }}
+          action={
+            <Chip
+              size="small"
+              color={cacheStatus.cache.is_stale ? 'warning' : 'success'}
+              label={cacheStatus.cache.refresh_state}
+            />
+          }
+        >
+          Last fetched: {formatDateTime(cacheStatus.cache.fetched_at)} · Data age: {formatAge(cacheStatus.cache.fetched_at)}
+          {cacheStatus.latest_runs.scheduled && (
+            <> · Last scheduled run: {cacheStatus.latest_runs.scheduled.status}</>
+          )}
+          {cacheStatus.latest_runs.manual && (
+            <> · Last manual run: {cacheStatus.latest_runs.manual.status}</>
+          )}
+        </Alert>
+      )}
+
+      {activeRun && (
+        <Alert severity={activeRun.status === 'failed' ? 'error' : activeRun.status === 'partial' ? 'warning' : 'info'} sx={{ mb: 2 }}>
+          Manual refresh {activeRun.status}
+          {activeRun.farms_processed || activeRun.houses_processed
+            ? ` · farms ${activeRun.farms_processed} · houses ${activeRun.houses_processed}`
+            : ''}
+          {activeRun.error_summary ? ` · ${activeRun.error_summary}` : ''}
+        </Alert>
+      )}
+
+      {data.houses.length === 0 && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          No cached monitoring data is available yet. Use Run now to queue a refresh.
+        </Alert>
+      )}
 
       <Grid container spacing={2}>
         {data.houses.map((house: any) => {
@@ -256,4 +393,3 @@ const FarmHousesMonitoring: React.FC = () => {
 };
 
 export default FarmHousesMonitoring;
-

--- a/frontend/src/services/monitoringApi.ts
+++ b/frontend/src/services/monitoringApi.ts
@@ -12,7 +12,13 @@ import {
   FarmDataQualityResponse,
   MonitoringTrendsResponse,
   FlockRiskScore,
+  FarmMonitoringCacheStatus,
+  MonitoringCacheRefreshRun,
+  MonitoringCacheMeta,
+  MonitoringDataMode,
 } from '../types/monitoring';
+
+export const MONITORING_DATA_MODE_STORAGE_KEY = 'monitoringDataMode';
 
 class MonitoringApiService {
   private baseURL: string;
@@ -27,15 +33,44 @@ class MonitoringApiService {
     return token ? { Authorization: `Token ${token}` } : {};
   }
 
+  getMonitoringDataMode(): MonitoringDataMode {
+    if (typeof window === 'undefined') return 'cache_only';
+    const stored = window.sessionStorage.getItem(MONITORING_DATA_MODE_STORAGE_KEY);
+    return stored === 'cached_then_live' ? 'cached_then_live' : 'cache_only';
+  }
+
+  setMonitoringDataMode(mode: MonitoringDataMode) {
+    if (typeof window !== 'undefined') {
+      window.sessionStorage.setItem(MONITORING_DATA_MODE_STORAGE_KEY, mode);
+    }
+  }
+
+  private unwrapMonitoringResponse<T extends Record<string, any>>(payload: any): T & { meta?: MonitoringCacheMeta } {
+    const inner = payload?.success && payload?.data ? payload.data : payload;
+    if (inner?.data && typeof inner.data === 'object') {
+      return {
+        ...inner.data,
+        meta: inner.meta || payload?.meta?.freshness,
+      };
+    }
+    if (payload?.success && payload?.data && typeof payload.data === 'object') {
+      return {
+        ...payload.data,
+        meta: payload.meta?.freshness || payload.meta,
+      };
+    }
+    return inner;
+  }
+
   /**
    * Get latest monitoring snapshot for a house
    */
-  async getHouseLatestMonitoring(houseId: number): Promise<HouseMonitoringSnapshot> {
+  async getHouseLatestMonitoring(houseId: number, mode: MonitoringDataMode = this.getMonitoringDataMode()): Promise<HouseMonitoringSnapshot> {
     const response = await api.get(`/houses/${houseId}/monitoring/latest/`, {
-      params: { mode: 'cached' },
+      params: { mode },
       headers: this.getAuthHeaders()
     });
-    return response.data;
+    return this.unwrapMonitoringResponse<HouseMonitoringSnapshot>(response.data);
   }
 
   /**
@@ -46,7 +81,7 @@ class MonitoringApiService {
     startDate?: string,
     endDate?: string,
     limit: number = 100,
-    mode?: 'cached' | 'live'
+    mode?: 'cached' | 'cache_only' | 'live' | 'cached_then_live'
   ): Promise<MonitoringHistoryResponse> {
     const params: any = { limit };
     if (startDate) params.start_date = startDate;
@@ -57,7 +92,7 @@ class MonitoringApiService {
       params,
       headers: this.getAuthHeaders()
     });
-    return response.data?.data ?? response.data;
+    return this.unwrapMonitoringResponse<MonitoringHistoryResponse>(response.data);
   }
 
   /**
@@ -81,9 +116,9 @@ class MonitoringApiService {
    */
   async getHouseMonitoringKpis(
     houseId: number,
-    options?: { dodReferenceDate?: string | null; cacheBust?: string | number }
+    options?: { dodReferenceDate?: string | null; cacheBust?: string | number; mode?: MonitoringDataMode }
   ): Promise<HouseMonitoringKpis> {
-    const params: Record<string, string> = { mode: 'cached' };
+    const params: Record<string, string> = { mode: options?.mode || this.getMonitoringDataMode() };
     if (options?.dodReferenceDate) {
       params.dod_reference_date = options.dodReferenceDate;
     }
@@ -94,29 +129,50 @@ class MonitoringApiService {
       headers: this.getAuthHeaders(),
       params,
     });
-    return response.data;
+    return this.unwrapMonitoringResponse<HouseMonitoringKpis>(response.data);
   }
 
   /**
    * Get latest monitoring data for all houses in a farm
    */
-  async getFarmHousesMonitoring(farmId: number): Promise<FarmHousesMonitoringResponse> {
+  async getFarmHousesMonitoring(farmId: number, mode: MonitoringDataMode = this.getMonitoringDataMode()): Promise<FarmHousesMonitoringResponse> {
     const response = await api.get(`/farms/${farmId}/houses/monitoring/all/`, {
-      params: { mode: 'cached' },
+      params: { mode },
       headers: this.getAuthHeaders()
     });
-    return response.data;
+    return this.unwrapMonitoringResponse<FarmHousesMonitoringResponse>(response.data);
   }
 
   /**
    * Get dashboard data with alerts and summaries for all houses
    */
-  async getFarmMonitoringDashboard(farmId: number): Promise<MonitoringDashboardData> {
+  async getFarmMonitoringDashboard(farmId: number, mode: MonitoringDataMode = this.getMonitoringDataMode()): Promise<MonitoringDashboardData> {
     const response = await api.get(`/farms/${farmId}/houses/monitoring/dashboard/`, {
-      params: { mode: 'cached' },
+      params: { mode },
       headers: this.getAuthHeaders()
     });
-    return response.data;
+    return this.unwrapMonitoringResponse<MonitoringDashboardData>(response.data);
+  }
+
+  async getFarmMonitoringCacheStatus(farmId: number): Promise<FarmMonitoringCacheStatus> {
+    const response = await api.get(`/farms/${farmId}/houses/monitoring/cache-status/`, {
+      headers: this.getAuthHeaders(),
+    });
+    return response.data?.data ?? response.data;
+  }
+
+  async queueMonitoringCacheRefresh(): Promise<MonitoringCacheRefreshRun> {
+    const response = await api.post(`/farms/monitoring/cache-refresh/`, {}, {
+      headers: this.getAuthHeaders(),
+    });
+    return response.data?.data ?? response.data;
+  }
+
+  async getMonitoringCacheRefreshRun(runId: string): Promise<MonitoringCacheRefreshRun> {
+    const response = await api.get(`/farms/monitoring/cache-refresh/${runId}/`, {
+      headers: this.getAuthHeaders(),
+    });
+    return response.data?.data ?? response.data;
   }
 
   async getFarmWaterHistoryComparison(
@@ -187,9 +243,10 @@ class MonitoringApiService {
    */
   async getHouseHeaterHistory(
     houseId: number,
-    cacheBust?: string | number
+    cacheBust?: string | number,
+    mode: MonitoringDataMode = this.getMonitoringDataMode()
   ): Promise<{ heater_history: Record<string, unknown> }> {
-    const params: Record<string, string> = { mode: 'cached' };
+    const params: Record<string, string> = { mode };
     if (cacheBust != null) {
       params._ = String(cacheBust);
     }
@@ -197,7 +254,7 @@ class MonitoringApiService {
       headers: this.getAuthHeaders(),
       params,
     });
-    return response.data;
+    return this.unwrapMonitoringResponse<{ heater_history: Record<string, unknown> }>(response.data);
   }
 
   /**

--- a/frontend/src/types/monitoring.ts
+++ b/frontend/src/types/monitoring.ts
@@ -1,5 +1,62 @@
 // Monitoring data types for house monitoring snapshots
 
+export type MonitoringDataMode = 'cache_only' | 'cached_then_live';
+
+export interface MonitoringCacheMeta {
+  fetched_at?: string | null;
+  source_timestamp?: string | null;
+  age_seconds?: number | null;
+  is_stale?: boolean;
+  refresh_state?: string;
+  can_refresh_now?: boolean;
+  [key: string]: unknown;
+}
+
+export interface MonitoringCacheRefreshRun {
+  run_id: string;
+  trigger_type: 'scheduled' | 'manual';
+  status: 'queued' | 'running' | 'success' | 'partial' | 'failed';
+  started_at: string | null;
+  completed_at: string | null;
+  farms_processed: number;
+  houses_processed: number;
+  result_payload: {
+    farm_count?: number;
+    max_workers?: number;
+    farms?: Array<{
+      farm_id: number;
+      farm_name?: string;
+      status: string;
+      message?: string;
+      houses_processed?: number;
+      cache_fetched_at?: string | null;
+      cache_source_timestamp?: string | null;
+    }>;
+  };
+  error_summary: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface FarmMonitoringCacheStatus {
+  farm_id: number;
+  farm_name: string;
+  cache: {
+    exists: boolean;
+    fetched_at: string | null;
+    source_timestamp: string | null;
+    age_seconds: number | null;
+    is_stale: boolean;
+    refresh_state: string;
+    last_error: string;
+  };
+  worker_interval_seconds: number;
+  latest_runs: {
+    scheduled: MonitoringCacheRefreshRun | null;
+    manual: MonitoringCacheRefreshRun | null;
+  };
+}
+
 export interface HouseMonitoringSnapshot {
   id: number;
   house: number;
@@ -53,6 +110,7 @@ export interface HouseMonitoringSnapshot {
     connectivity: Record<string, number | string | null>;
     digital_outputs: Record<string, any>;
   };
+  meta?: MonitoringCacheMeta;
 }
 
 export interface TemperatureSensorData {
@@ -190,6 +248,7 @@ export interface FarmHousesMonitoringResponse {
     status: 'no_data';
     message: string;
   })[];
+  meta?: MonitoringCacheMeta;
 }
 
 export interface MonitoringDashboardData {
@@ -213,6 +272,7 @@ export interface MonitoringDashboardData {
     connected: number;
     disconnected: number;
   };
+  meta?: MonitoringCacheMeta;
 }
 
 export interface DayOverDayDelta {


### PR DESCRIPTION
## Summary
- Add `MonitoringCacheRefreshRun` tracking for scheduled and manual cache refreshes, with parallel farm execution in the worker and a bounded thread pool.
- Expose cache refresh APIs (`POST` queue, `GET` run status, `GET` farm cache status) and a `cache_only` monitoring mode that reads DB cache without calling Rotem.
- Update farm monitoring UIs with session-scoped data mode toggle (Job cache vs Current), cache freshness display, and a non-blocking **Run now** action with status polling.

## Test plan
- [ ] Run `python manage.py migrate` (applies `0016_monitoring_cache_refresh_run`)
- [ ] Run `python manage.py test houses.tests.test_monitoring_cache_refresh`
- [ ] Confirm Railway worker runs `monitoring_cache_worker.py` and picks up manual runs during sleep polling
- [ ] Open farm dashboard → verify **Job cache** is default, freshness alert shows last fetched + age
- [ ] Click **Run now** → verify queued/running/success (or partial/failed) states and dashboard reload after completion
- [ ] Toggle **Current** → verify read-through behavior still works for stale/missing cache
- [ ] `GET .../monitoring/dashboard/?mode=cache_only` returns cached data without Rotem traffic


Made with [Cursor](https://cursor.com)