### PR TITLE
Add farm transfer between organizations

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -39,43 +39,4 @@ jobs:
         cd frontend
         npm run build
       env:
-        REACT_APP_API_URL: https://your-backend.railway.app/api
-
-  deploy-vercel:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Deploy to Vercel
-      uses: amondnet/vercel-action@v25
-      with:
-        vercel-token: ${{ secrets.VERCEL_TOKEN }}
-        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-        working-directory: ./frontend
-        vercel-args: '--prod'
-
-  deploy-netlify:
-    needs: test
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Deploy to Netlify
-      uses: nwtgck/actions-netlify@v2.0
-      with:
-        publish-dir: './frontend/build'
-        production-branch: main
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        deploy-message: "Deploy from GitHub Actions"
-        enable-pull-request-comment: false
-        enable-commit-comment: true
-        overwrites-pull-request-comment: true
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        REACT_APP_API_URL: https://farm-management-production-54e4.up.railway.app/api

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -40,3 +40,71 @@ jobs:
         npm run build
       env:
         REACT_APP_API_URL: https://farm-management-production-54e4.up.railway.app/api
+
+  deploy-vercel:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check Vercel credentials
+      id: vercel_creds
+      env:
+        VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      run: |
+        if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping Vercel deploy: add VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID repository secrets."
+        fi
+
+    - name: Deploy to Vercel
+      if: steps.vercel_creds.outputs.ready == 'true'
+      uses: amondnet/vercel-action@v25
+      with:
+        vercel-token: ${{ secrets.VERCEL_TOKEN }}
+        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+        working-directory: ./frontend
+        vercel-args: '--prod'
+
+  deploy-netlify:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check Netlify credentials
+      id: netlify_creds
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      run: |
+        if [ -n "$NETLIFY_AUTH_TOKEN" ] && [ -n "$NETLIFY_SITE_ID" ]; then
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          echo "Skipping Netlify deploy: add NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID repository secrets."
+        fi
+
+    - name: Deploy to Netlify
+      if: steps.netlify_creds.outputs.ready == 'true'
+      uses: nwtgck/actions-netlify@v2.0
+      with:
+        publish-dir: './frontend/build'
+        production-branch: main
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: "Deploy from GitHub Actions"
+        enable-pull-request-comment: false
+        enable-commit-comment: true
+        overwrites-pull-request-comment: true
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/backend/farms/serializers.py
+++ b/backend/farms/serializers.py
@@ -35,7 +35,7 @@ class FarmSerializer(serializers.ModelSerializer):
             'rotem_gateway_name', 'rotem_gateway_alias',
             'created_at', 'updated_at'
         ]
-        read_only_fields = ['id', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'organization', 'created_at', 'updated_at']
         extra_kwargs = {
             'rotem_password': {'write_only': True}
         }
@@ -62,6 +62,15 @@ class FarmSerializer(serializers.ModelSerializer):
         ]
 
 
+class FarmCreateSerializer(FarmSerializer):
+    class Meta(FarmSerializer.Meta):
+        read_only_fields = ['id', 'created_at', 'updated_at']
+
+
+class FarmTransferSerializer(serializers.Serializer):
+    target_organization_id = serializers.UUIDField()
+
+
 class FarmListSerializer(serializers.ModelSerializer):
     total_houses = serializers.ReadOnlyField()
     active_houses = serializers.ReadOnlyField()
@@ -76,6 +85,7 @@ class FarmListSerializer(serializers.ModelSerializer):
             'integration_type', 'integration_status', 'last_sync',
             'is_integrated', 'integration_display_name', 'rotem_farm_id'
         ]
+        read_only_fields = ['id', 'organization']
 
 
 class ProgramTaskSerializer(serializers.ModelSerializer):
@@ -157,7 +167,7 @@ class FarmWithProgramSerializer(serializers.ModelSerializer):
             'is_active', 'total_houses', 'active_houses', 'workers',
             'created_at', 'updated_at'
         ]
-        read_only_fields = ['id', 'created_at', 'updated_at']
+        read_only_fields = ['id', 'organization', 'created_at', 'updated_at']
 
     def create(self, validated_data):
         program_id = validated_data.pop('program_id', None)

--- a/backend/farms/tests/test_farm_transfer.py
+++ b/backend/farms/tests/test_farm_transfer.py
@@ -1,0 +1,203 @@
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from analytics.models import Dashboard
+from farms.models import Farm
+from houses.models import House
+from integrations.models import AutomationWorkflow
+from organizations.models import Organization, OrganizationUser
+
+
+def _response_data(response):
+    if isinstance(response.data, dict) and 'data' in response.data:
+        return response.data['data'] or response.data.get('error')
+    return response.data
+
+
+class FarmTransferApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        user_model = get_user_model()
+
+        self.admin_user = user_model.objects.create_user(
+            username='transfer_admin',
+            email='admin@test.com',
+            password='testpass123',
+        )
+        self.member_user = user_model.objects.create_user(
+            username='transfer_member',
+            email='member@test.com',
+            password='testpass123',
+        )
+
+        self.org_source = Organization.objects.create(
+            name='Source Org',
+            slug='source-org',
+            contact_email='source@test.com',
+            max_farms=5,
+        )
+        self.org_target = Organization.objects.create(
+            name='Target Org',
+            slug='target-org',
+            contact_email='target@test.com',
+            max_farms=5,
+        )
+        self.org_full = Organization.objects.create(
+            name='Full Org',
+            slug='full-org',
+            contact_email='full@test.com',
+            max_farms=0,
+        )
+
+        OrganizationUser.objects.create(
+            organization=self.org_source,
+            user=self.admin_user,
+            role='owner',
+            is_active=True,
+        )
+        OrganizationUser.objects.create(
+            organization=self.org_target,
+            user=self.admin_user,
+            role='admin',
+            is_active=True,
+        )
+        OrganizationUser.objects.create(
+            organization=self.org_full,
+            user=self.admin_user,
+            role='owner',
+            is_active=True,
+        )
+        OrganizationUser.objects.create(
+            organization=self.org_source,
+            user=self.member_user,
+            role='worker',
+            is_active=True,
+        )
+
+        self.farm = Farm.objects.create(
+            organization=self.org_source,
+            name='Transfer Farm',
+            location='Here',
+            contact_person='Person',
+            contact_phone='0000000000',
+            contact_email='farm@test.com',
+            is_active=True,
+        )
+        House.objects.create(
+            farm=self.farm,
+            house_number=1,
+            capacity=1000,
+            chicken_in_date=date.today() - timedelta(days=5),
+            current_age_days=5,
+            is_active=True,
+        )
+
+        self.dashboard = Dashboard.objects.create(
+            name='Farm BI',
+            dashboard_type='farm',
+            organization=self.org_source,
+            farm=self.farm,
+            created_by=self.admin_user,
+        )
+        self.workflow = AutomationWorkflow.objects.create(
+            slug='farm_report',
+            name='Farm Report',
+            webhook_url='https://n8n.example.com/webhook/farm-report',
+            organization=self.org_source,
+            farm=self.farm,
+            is_active=True,
+        )
+
+        self.admin_token = Token.objects.create(user=self.admin_user)
+        self.member_token = Token.objects.create(user=self.member_user)
+
+    def test_transfer_success(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.post(
+            f'/api/farms/{self.farm.id}/transfer/',
+            {'target_organization_id': str(self.org_target.id)},
+            format='json',
+        )
+        data = _response_data(response)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(data['status'], 'success')
+
+        self.farm.refresh_from_db()
+        self.assertEqual(self.farm.organization_id, self.org_target.id)
+
+        self.dashboard.refresh_from_db()
+        self.assertEqual(self.dashboard.organization_id, self.org_target.id)
+
+        self.workflow.refresh_from_db()
+        self.assertEqual(self.workflow.organization_id, self.org_target.id)
+
+    def test_member_cannot_transfer(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.member_token.key}')
+        response = self.client.post(
+            f'/api/farms/{self.farm.id}/transfer/',
+            {'target_organization_id': str(self.org_target.id)},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cannot_transfer_to_same_org(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.post(
+            f'/api/farms/{self.farm.id}/transfer/',
+            {'target_organization_id': str(self.org_source.id)},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_cannot_transfer_when_target_at_limit(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.post(
+            f'/api/farms/{self.farm.id}/transfer/',
+            {'target_organization_id': str(self.org_full.id)},
+            format='json',
+        )
+        data = _response_data(response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(data.get('code'), 'farm_limit_reached')
+
+    def test_farm_list_scoped_after_transfer(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        self.client.post(
+            f'/api/farms/{self.farm.id}/transfer/',
+            {'target_organization_id': str(self.org_target.id)},
+            format='json',
+        )
+
+        source_response = self.client.get(
+            '/api/farms/',
+            {'organization_id': str(self.org_source.id)},
+        )
+        source_data = _response_data(source_response)
+        source_results = source_data.get('results', source_data) if isinstance(source_data, dict) else source_data
+        source_ids = [f['id'] for f in source_results]
+
+        target_response = self.client.get(
+            '/api/farms/',
+            {'organization_id': str(self.org_target.id)},
+        )
+        target_data = _response_data(target_response)
+        target_results = target_data.get('results', target_data) if isinstance(target_data, dict) else target_data
+        target_ids = [f['id'] for f in target_results]
+        self.assertNotIn(self.farm.id, source_ids)
+        self.assertIn(self.farm.id, target_ids)
+
+    def test_organization_not_writable_via_patch(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.admin_token.key}')
+        response = self.client.patch(
+            f'/api/farms/{self.farm.id}/',
+            {'organization': str(self.org_target.id)},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.farm.refresh_from_db()
+        self.assertEqual(self.farm.organization_id, self.org_source.id)

--- a/backend/farms/transfer_service.py
+++ b/backend/farms/transfer_service.py
@@ -1,0 +1,60 @@
+from django.db import transaction
+
+from analytics.models import Dashboard
+from analytics.services import ensure_farm_dashboard
+from integrations.models import AutomationWorkflow
+from organizations.models import Organization
+
+
+class FarmTransferError(Exception):
+    def __init__(self, message, code='transfer_error'):
+        self.message = message
+        self.code = code
+        super().__init__(message)
+
+
+class FarmTransferService:
+    @staticmethod
+    @transaction.atomic
+    def transfer(farm, target_org: Organization, actor):
+        if farm.organization_id is None:
+            raise FarmTransferError(
+                'Farm has no organization assigned',
+                code='no_source_organization',
+            )
+
+        if farm.organization_id == target_org.id:
+            raise FarmTransferError(
+                'Farm already belongs to this organization',
+                code='same_organization',
+            )
+
+        if not target_org.can_add_farm():
+            raise FarmTransferError(
+                f'Target organization has reached its farm limit ({target_org.max_farms})',
+                code='farm_limit_reached',
+            )
+
+        previous_organization_id = farm.organization_id
+
+        dashboards_updated = Dashboard.objects.filter(
+            farm=farm,
+            dashboard_type='farm',
+        ).update(organization=target_org)
+
+        automation_workflows_updated = AutomationWorkflow.objects.filter(
+            farm=farm,
+        ).update(organization=target_org)
+
+        farm.organization = target_org
+        farm.save(update_fields=['organization', 'updated_at'])
+
+        ensure_farm_dashboard(farm, actor)
+
+        return {
+            'farm_id': farm.id,
+            'previous_organization_id': str(previous_organization_id),
+            'organization_id': str(target_org.id),
+            'dashboards_updated': dashboards_updated,
+            'automation_workflows_updated': automation_workflows_updated,
+        }

--- a/backend/farms/views.py
+++ b/backend/farms/views.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from datetime import timedelta
 from .models import Farm, Worker, Program, ProgramTask, ProgramChangeLog, Breed, Flock, FlockPerformance, FlockComparison, MortalityRecord
 from .serializers import (
-    FarmSerializer, FarmListSerializer, WorkerSerializer,
+    FarmSerializer, FarmCreateSerializer, FarmListSerializer, FarmTransferSerializer, WorkerSerializer,
     ProgramSerializer, ProgramListSerializer, ProgramTaskSerializer,
     FarmWithProgramSerializer, BreedSerializer, BreedListSerializer,
     FlockSerializer, FlockListSerializer, FlockPerformanceSerializer,
@@ -19,9 +19,12 @@ from .serializers import (
     MortalitySummarySerializer
 )
 from .program_change_service import ProgramChangeService
+from .transfer_service import FarmTransferService, FarmTransferError
 from integrations.rotem import RotemIntegration
 from integrations.models import IntegrationLog, IntegrationError
 from analytics.services import ensure_farm_dashboard
+from organizations.models import Organization
+from organizations.permissions import user_is_org_admin, user_can_access_organization
 
 
 def user_accessible_organization_ids(request):
@@ -70,6 +73,11 @@ class FarmViewSet(ModelViewSet):
         
         return queryset.order_by('name')
 
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return FarmCreateSerializer
+        return FarmSerializer
+
     def perform_create(self, serializer):
         farm = serializer.save()
         if self.request.user.is_authenticated:
@@ -105,6 +113,53 @@ class FarmViewSet(ModelViewSet):
         
         return response
     
+    @action(detail=True, methods=['post'])
+    def transfer(self, request, pk=None):
+        """Transfer farm to another organization (requires admin on both orgs)."""
+        farm = self.get_object()
+        serializer = FarmTransferSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        target_organization_id = serializer.validated_data['target_organization_id']
+
+        if farm.organization_id is None:
+            return Response(
+                {'error': 'Farm has no source organization'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if not user_is_org_admin(request.user, farm.organization_id):
+            return Response(
+                {'error': 'You must be an administrator of the source organization'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        if not user_is_org_admin(request.user, target_organization_id):
+            return Response(
+                {'error': 'You must be an administrator of the target organization'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        if not user_can_access_organization(request.user, target_organization_id):
+            return Response(
+                {'error': 'Target organization not found or not accessible'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        target_org = get_object_or_404(Organization, id=target_organization_id, is_active=True)
+
+        try:
+            result = FarmTransferService.transfer(farm, target_org, request.user)
+            return Response({
+                'status': 'success',
+                'message': f'Farm transferred to {target_org.name}',
+                **result,
+            })
+        except FarmTransferError as exc:
+            status_code = status.HTTP_400_BAD_REQUEST
+            if exc.code == 'farm_limit_reached':
+                status_code = status.HTTP_400_BAD_REQUEST
+            return Response({'error': exc.message, 'code': exc.code}, status=status_code)
+
     @action(detail=True, methods=['post'])
     def configure_integration(self, request, pk=None):
         """Configure system integration for a farm"""

--- a/backend/integrations/permissions.py
+++ b/backend/integrations/permissions.py
@@ -1,34 +1,11 @@
-from organizations.models import OrganizationUser
+from organizations.permissions import (
+    user_accessible_organization_ids,
+    user_can_access_organization,
+    user_is_org_admin,
+)
 
-
-def user_accessible_organization_ids(user):
-    if not user.is_authenticated:
-        return []
-    if user.is_staff:
-        return None
-    return list(
-        OrganizationUser.objects.filter(user=user, is_active=True).values_list(
-            'organization_id', flat=True
-        )
-    )
-
-
-def user_can_access_organization(user, organization_id) -> bool:
-    if user.is_staff:
-        return True
-    return OrganizationUser.objects.filter(
-        organization_id=organization_id,
-        user=user,
-        is_active=True,
-    ).exists()
-
-
-def user_is_org_admin(user, organization_id) -> bool:
-    if user.is_staff:
-        return True
-    return OrganizationUser.objects.filter(
-        organization_id=organization_id,
-        user=user,
-        is_active=True,
-        role__in=['owner', 'admin'],
-    ).exists()
+__all__ = [
+    'user_accessible_organization_ids',
+    'user_can_access_organization',
+    'user_is_org_admin',
+]

--- a/backend/organizations/permissions.py
+++ b/backend/organizations/permissions.py
@@ -1,0 +1,36 @@
+from organizations.models import OrganizationUser
+
+
+def user_accessible_organization_ids(user):
+    if not user.is_authenticated:
+        return []
+    if user.is_staff:
+        return None
+    return list(
+        OrganizationUser.objects.filter(user=user, is_active=True).values_list(
+            'organization_id', flat=True
+        )
+    )
+
+
+def user_can_access_organization(user, organization_id) -> bool:
+    if user.is_staff:
+        return True
+    return OrganizationUser.objects.filter(
+        organization_id=organization_id,
+        user=user,
+        is_active=True,
+    ).exists()
+
+
+def user_is_org_admin(user, organization_id) -> bool:
+    if user.is_staff:
+        return True
+    if organization_id is None:
+        return False
+    return OrganizationUser.objects.filter(
+        organization_id=organization_id,
+        user=user,
+        is_active=True,
+        role__in=['owner', 'admin'],
+    ).exists()

--- a/frontend/src/components/farms/MoveFarmToOrganizationDialog.tsx
+++ b/frontend/src/components/farms/MoveFarmToOrganizationDialog.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useOrganization } from '../../contexts/OrganizationContext';
+import { farmsApi, extractApiErrorMessage } from '../../services/farmsApi';
+
+interface MoveFarmToOrganizationDialogProps {
+  open: boolean;
+  farmId: number;
+  farmName: string;
+  sourceOrganizationId: string | null | undefined;
+  onClose: () => void;
+  onSuccess: (targetOrganizationId: string) => void;
+}
+
+const MoveFarmToOrganizationDialog: React.FC<MoveFarmToOrganizationDialogProps> = ({
+  open,
+  farmId,
+  farmName,
+  sourceOrganizationId,
+  onClose,
+  onSuccess,
+}) => {
+  const { organizations } = useOrganization();
+  const [targetOrganizationId, setTargetOrganizationId] = useState('');
+  const [confirmName, setConfirmName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const eligibleTargetOrganizations = useMemo(
+    () =>
+      organizations
+        .filter(
+          (membership) =>
+            (membership.is_owner || membership.is_admin) &&
+            membership.organization.id !== sourceOrganizationId
+        )
+        .map((membership) => membership.organization),
+    [organizations, sourceOrganizationId]
+  );
+
+  const canSubmit =
+    Boolean(targetOrganizationId) &&
+    confirmName.trim() === farmName.trim() &&
+    !submitting;
+
+  const handleClose = () => {
+    if (submitting) {
+      return;
+    }
+    setTargetOrganizationId('');
+    setConfirmName('');
+    setError(null);
+    onClose();
+  };
+
+  const handleTransfer = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await farmsApi.transferFarm(farmId, targetOrganizationId);
+      const transferredTo = targetOrganizationId;
+      setTargetOrganizationId('');
+      setConfirmName('');
+      onSuccess(transferredTo);
+      onClose();
+    } catch (err) {
+      setError(extractApiErrorMessage(err, 'Failed to transfer farm'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Move farm to another organization</DialogTitle>
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Move <strong>{farmName}</strong> and all of its data to a different organization.
+          You must be an administrator of both the current and target organizations.
+        </Typography>
+
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          <Typography variant="body2" component="div">
+            <ul style={{ margin: 0, paddingLeft: 20 }}>
+              <li>Houses, tasks, and flock data move with the farm.</li>
+              <li>Organization-specific n8n workflows may need reconfiguration.</li>
+              <li>The farm will disappear from the source organization for other members.</li>
+            </ul>
+          </Typography>
+        </Alert>
+
+        {eligibleTargetOrganizations.length === 0 ? (
+          <Alert severity="info">
+            No other organizations are available. You need admin access on at least one
+            other organization to transfer this farm.
+          </Alert>
+        ) : (
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel id="target-org-label">Target organization</InputLabel>
+            <Select
+              labelId="target-org-label"
+              label="Target organization"
+              value={targetOrganizationId}
+              onChange={(event) => setTargetOrganizationId(event.target.value)}
+            >
+              {eligibleTargetOrganizations.map((org) => (
+                <MenuItem key={org.id} value={org.id}>
+                  {org.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        <TextField
+          fullWidth
+          label={`Type "${farmName}" to confirm`}
+          value={confirmName}
+          onChange={(event) => setConfirmName(event.target.value)}
+          disabled={eligibleTargetOrganizations.length === 0}
+          autoComplete="off"
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleTransfer}
+          variant="contained"
+          color="warning"
+          disabled={!canSubmit || eligibleTargetOrganizations.length === 0}
+          startIcon={submitting ? <CircularProgress size={18} color="inherit" /> : undefined}
+        >
+          {submitting ? 'Transferring...' : 'Transfer'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MoveFarmToOrganizationDialog;

--- a/frontend/src/components/farms/UnifiedFarmDashboard.tsx
+++ b/frontend/src/components/farms/UnifiedFarmDashboard.tsx
@@ -74,9 +74,12 @@ import {
 import MonitoringDataQualityPanel from '../monitoring/MonitoringDataQualityPanel';
 import IntegrationManagement from './IntegrationManagement';
 import FarmAutomationsPanel from './FarmAutomationsPanel';
+import MoveFarmToOrganizationDialog from './MoveFarmToOrganizationDialog';
 import { useOrganization } from '../../contexts/OrganizationContext';
+import { useFarm } from '../../contexts/FarmContext';
 import { useProgram } from '../../contexts/ProgramContext';
 import { rotemApi } from '../../services/rotemApi';
+import { organizationsApi } from '../../services/organizationsApi';
 import { lastHouseStorageKey } from '../../utils/houseDetailUrl';
 // Removed logger import - using console instead
 
@@ -223,7 +226,8 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
   const { farmId } = useParams<{ farmId: string }>();
   const navigate = useNavigate();
   const { programs, fetchPrograms } = useProgram();
-  const { currentOrganization } = useOrganization();
+  const { currentOrganization, isOwner, isAdmin, setCurrentOrganization, fetchMyOrganizations } = useOrganization();
+  const { fetchFarms } = useFarm();
   const [farm, setFarm] = useState<Farm | null>(propFarm || null);
   const [loading, setLoading] = useState(!propFarm);
   const [error, setError] = useState<string | null>(null);
@@ -247,6 +251,7 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
   const [queueingMonitoringRefresh, setQueueingMonitoringRefresh] = useState(false);
   const [clockNow, setClockNow] = useState(() => Date.now());
   const [integrationDialogOpen, setIntegrationDialogOpen] = useState(false);
+  const [moveDialogOpen, setMoveDialogOpen] = useState(false);
   
   // Water anomaly detection state
   const [detectingWaterAnomalies, setDetectingWaterAnomalies] = useState(false);
@@ -811,6 +816,16 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
                     Generate Houses & Tasks
                   </Button>
                 </>
+              )}
+              {(isOwner || isAdmin) && (
+                <Button
+                  variant="outlined"
+                  startIcon={<CompareArrows />}
+                  onClick={() => setMoveDialogOpen(true)}
+                  size="small"
+                >
+                  Move to organization
+                </Button>
               )}
               <Button
                 variant="outlined"
@@ -1799,6 +1814,40 @@ const UnifiedFarmDashboard: React.FC<UnifiedFarmDashboardProps> = ({
       )}
 
       {/* Integration Management Dialog */}
+      {farm && (
+        <MoveFarmToOrganizationDialog
+          open={moveDialogOpen}
+          farmId={farm.id}
+          farmName={farm.name}
+          sourceOrganizationId={currentOrganization?.id}
+          onClose={() => setMoveDialogOpen(false)}
+          onSuccess={async (targetOrganizationId) => {
+            const sourceOrgId = currentOrganization?.id;
+            const memberships = await organizationsApi.getMyOrganizations();
+            await fetchMyOrganizations();
+            await fetchFarms();
+
+            if (sourceOrgId && sourceOrgId !== targetOrganizationId) {
+              const targetMembership = memberships.find(
+                (membership) => membership.organization.id === targetOrganizationId
+              );
+              if (targetMembership) {
+                setCurrentOrganization(targetMembership.organization);
+              } else {
+                navigate('/farms');
+                return;
+              }
+            }
+
+            if (onRefresh) {
+              onRefresh();
+            } else {
+              await fetchFarmData();
+            }
+          }}
+        />
+      )}
+
       {farm && (
         <IntegrationManagement
           farm={{

--- a/frontend/src/services/farmsApi.ts
+++ b/frontend/src/services/farmsApi.ts
@@ -1,0 +1,54 @@
+import api from './api';
+
+export interface FarmTransferResult {
+  status: 'success';
+  message: string;
+  farm_id: number;
+  previous_organization_id: string;
+  organization_id: string;
+  dashboards_updated: number;
+  automation_workflows_updated: number;
+}
+
+function unwrapResponse<T>(response: { data: T | { data: T } }): T {
+  const payload = response.data as { data?: T };
+  return payload?.data ?? (response.data as T);
+}
+
+export function extractApiErrorMessage(err: unknown, fallback = 'Request failed'): string {
+  const axiosErr = err as { response?: { data?: Record<string, unknown> } };
+  const data = axiosErr.response?.data;
+  if (!data) {
+    return fallback;
+  }
+
+  const errorField = data.error;
+  if (typeof errorField === 'string') {
+    return errorField;
+  }
+  if (errorField && typeof errorField === 'object') {
+    const nested = (errorField as { error?: string; message?: string }).error
+      || (errorField as { message?: string }).message;
+    if (nested) {
+      return nested;
+    }
+  }
+
+  if (typeof data.message === 'string') {
+    return data.message;
+  }
+
+  return fallback;
+}
+
+export const farmsApi = {
+  async transferFarm(
+    farmId: number,
+    targetOrganizationId: string
+  ): Promise<FarmTransferResult> {
+    const response = await api.post(`/farms/${farmId}/transfer/`, {
+      target_organization_id: targetOrganizationId,
+    });
+    return unwrapResponse<FarmTransferResult>(response);
+  },
+};


### PR DESCRIPTION
## Summary
- Add `FarmTransferService` and `POST /api/farms/{id}/transfer/` with dual org-admin checks, farm limit enforcement, and related dashboard/automation workflow updates.
- Make `organization` read-only on generic farm updates; add transfer API tests.
- Add farm dashboard UI: admin-only **Move to organization** button, confirmation dialog, and org/farm context refresh on success.

## Test plan
- [ ] Log in as admin of two orgs and transfer a farm from the farm dashboard
- [ ] Confirm farm appears under target org and disappears from source org
- [ ] Verify houses/tasks remain accessible on the farm dashboard after transfer
- [ ] Confirm non-admin members cannot see the transfer button and receive 403 from the API
- [ ] Run `python manage.py test farms.tests.test_farm_transfer`


Made with [Cursor](https://cursor.com)